### PR TITLE
fix: restore dark mode contrast and laptop layout

### DIFF
--- a/src/__tests__/calculator-form.test.tsx
+++ b/src/__tests__/calculator-form.test.tsx
@@ -110,4 +110,17 @@ describe("CalculatorForm", () => {
       expect(onInputsChange).toHaveBeenLastCalledWith(null);
     });
   });
+
+  it("avoids the rigid custom lg grid that causes laptop-width overlap", () => {
+    vi.mocked(useRegions).mockReturnValue({
+      regions,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<CalculatorForm onInputsChange={vi.fn()} />);
+
+    const form = screen.getByRole("form", { name: /vault pricing inputs/i });
+    expect(form.className).not.toMatch(/lg:grid-cols-\[/);
+  });
 });

--- a/src/__tests__/theme-contract.test.ts
+++ b/src/__tests__/theme-contract.test.ts
@@ -1,0 +1,59 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const indexCss = readFileSync(resolve(process.cwd(), "src/index.css"), "utf8");
+
+function getDarkSchemeRootBlock(source: string): string {
+  const mediaMatch = /@media\s*\(prefers-color-scheme:\s*dark\)\s*\{/.exec(
+    source,
+  );
+  const mediaStart = mediaMatch?.index ?? -1;
+
+  if (mediaStart === -1) {
+    throw new Error("Missing prefers-color-scheme dark media block");
+  }
+
+  const rootMatch = /:root\s*\{/.exec(source.slice(mediaStart));
+  const rootStart = rootMatch === null ? -1 : mediaStart + rootMatch.index;
+
+  if (rootStart === -1) {
+    throw new Error("Missing :root block inside dark media query");
+  }
+
+  const blockStart = source.indexOf("{", rootStart);
+  let depth = 0;
+
+  for (let index = blockStart; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (char === "{") {
+      depth += 1;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+
+      if (depth === 0) {
+        return source.slice(blockStart + 1, index);
+      }
+    }
+  }
+
+  throw new Error("Unclosed dark-mode :root block");
+}
+
+describe("dark theme contract", () => {
+  it("defines readable semantic foreground tokens for prefers-color-scheme dark", () => {
+    const darkRootBlock = getDarkSchemeRootBlock(indexCss);
+
+    expect(darkRootBlock).toContain("--background:");
+    expect(darkRootBlock).toContain("--foreground:");
+    expect(darkRootBlock).toContain("--card:");
+    expect(darkRootBlock).toContain("--card-foreground:");
+    expect(darkRootBlock).toContain("--popover:");
+    expect(darkRootBlock).toContain("--popover-foreground:");
+  });
+});

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -54,14 +54,16 @@ export function CalculatorForm({ onInputsChange }: CalculatorFormProps) {
       <CardContent className="py-6">
         <form
           aria-label="Vault pricing inputs"
-          className="grid gap-5 lg:grid-cols-[minmax(0,1.5fr)_minmax(14rem,1fr)_minmax(12rem,0.9fr)] lg:items-start"
+          className="grid gap-5 lg:grid-cols-2 lg:items-start"
         >
-          <RegionSelector
-            regions={regions}
-            isLoading={isLoading}
-            selectedRegion={selectedRegion}
-            onRegionChange={setSelectedRegion}
-          />
+          <div className="lg:col-span-2">
+            <RegionSelector
+              regions={regions}
+              isLoading={isLoading}
+              selectedRegion={selectedRegion}
+              onRegionChange={setSelectedRegion}
+            />
+          </div>
           <TermSelector value={termYears} onTermChange={setTermYears} />
           <CapacityInput
             value={capacityTiB}

--- a/src/index.css
+++ b/src/index.css
@@ -99,11 +99,24 @@
 
     /* Overrides for dark backgrounds */
     --background: oklch(0.15 0 0);
+    --foreground: oklch(0.985 0 0);
     --card: oklch(0.2 0 0);
+    --card-foreground: oklch(0.985 0 0);
     --popover: oklch(0.2 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
     --primary-foreground: oklch(0.15 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --destructive-foreground: oklch(0.985 0 0);
     --border: oklch(1 0 0 / 10%);
     --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
     --surface-gradient: linear-gradient(
       180deg,
       oklch(0.18 0.01 155 / 30%) 0%,
@@ -119,9 +132,22 @@
     --warning-muted: oklch(0.22 0.08 55);
     --info-muted: oklch(0.22 0.08 265);
 
+    /* Chart Colors */
+    --chart-1: oklch(0.87 0 0);
+    --chart-2: oklch(0.556 0 0);
+    --chart-3: oklch(0.439 0 0);
+    --chart-4: oklch(0.371 0 0);
+    --chart-5: oklch(0.269 0 0);
+
     /* Sidebar — Dark Mode */
     --sidebar: oklch(0.2 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.556 0 0);
   }
 }
 


### PR DESCRIPTION
## Summary
- restore the missing prefers-color-scheme dark semantic tokens so dark mode stays readable across the visible UI
- replace the rigid calculator large-screen grid with a two-column layout that keeps the region selector full width and prevents laptop-width overlap
- add regression coverage for the dark theme token contract and the calculator form layout

## Test Plan
- [x] npm run lint
- [x] npm run test:run
- [x] npm run build
- [x] browser-check dark mode readability and calculator layout at 1280px, 1366px, and 1440px via agent-browser
