### PR TITLE
fix(breakdown-table): show vault total in storage row

### DIFF
--- a/src/__tests__/cost-breakdown-table.test.tsx
+++ b/src/__tests__/cost-breakdown-table.test.tsx
@@ -22,7 +22,12 @@ describe("CostBreakdownTable", () => {
     expect(screen.getByText("Data Retrieval")).toBeInTheDocument();
     expect(screen.getByText("Internet Egress")).toBeInTheDocument();
 
-    expect(screen.getAllByText("--")).toHaveLength(10);
+    // Storage row shows vault totals; remaining 4 rows × 2 vault columns = 8 dashes
+    expect(screen.getAllByText("--")).toHaveLength(8);
+
+    // Vault totals appear in both the Storage row and the footer
+    expect(screen.getAllByText("$5,040.00").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("$8,640.00").length).toBeGreaterThanOrEqual(2);
 
     const footer = container.querySelector("tfoot");
     expect(footer).not.toBeNull();

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -39,14 +39,8 @@ interface BreakdownRow {
 const columnHelper = createColumnHelper<BreakdownRow>();
 
 function formatVaultTotal(result: VaultCostResult): string {
-  if (result.pricingTbd) {
-    return "TBD";
-  }
-
-  if (result.total === null) {
-    return "N/A";
-  }
-
+  if (result.pricingTbd) return "TBD";
+  if (result.total === null) return "N/A";
   return formatUSD(result.total);
 }
 
@@ -54,8 +48,8 @@ export function CostBreakdownTable({ comparison }: CostBreakdownTableProps) {
   const data: BreakdownRow[] = [
     {
       category: "Storage",
-      foundation: "--",
-      advanced: "--",
+      foundation: formatVaultTotal(comparison.vaultFoundation),
+      advanced: formatVaultTotal(comparison.vaultAdvanced),
       diyOption1: formatUSD(comparison.diyOption1.storage),
       diyOption2: formatUSD(comparison.diyOption2.storage),
     },


### PR DESCRIPTION
## Summary

- Vault pricing is a flat $/TB/month rate with no per-operation cost breakdown
- Previously all five rows showed `--` for both Vault editions, making the table look incomplete
- The Vault edition total is now surfaced in the **Storage** row, which is the correct semantic home for the cost
- Write Ops, Read Ops, Data Retrieval, and Internet Egress rows continue to show `--` for Vault (N/A by design)
- Footer totals are unchanged; N/A and TBD states are preserved correctly

## Test plan

- [x] `--` count in breakdown test updated from 10 → 8 (Storage row no longer contributes dashes)
- [x] New assertion confirms vault totals appear at least twice (Storage row + footer)
- [x] N/A / TBD test remains valid — `within(footer)` scoping still finds exactly one of each
- [x] `npm run test:run` — 103 tests pass
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)