### PR TITLE
feat(calculator): add exclude internet egress toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ function App() {
                 comparison={comparison}
                 capacityTiB={inputs.capacityTiB}
                 termYears={inputs.termYears}
+                excludeEgress={inputs.excludeEgress === true}
               />
             ) : null}
           </div>

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -182,6 +182,7 @@ describe("App", () => {
       regionId: "aws-us-east-1",
       termYears: 1,
       capacityTiB: 8,
+      excludeEgress: false,
     });
   }, 10_000);
 });

--- a/src/__tests__/calculator-form.test.tsx
+++ b/src/__tests__/calculator-form.test.tsx
@@ -61,6 +61,7 @@ describe("CalculatorForm", () => {
         regionId: "aws-us-east-1",
         termYears: 1,
         capacityTiB: 8,
+        excludeEgress: false,
       });
     });
 
@@ -71,6 +72,7 @@ describe("CalculatorForm", () => {
         regionId: "aws-us-east-1",
         termYears: 3,
         capacityTiB: 8,
+        excludeEgress: false,
       });
     });
   });
@@ -99,6 +101,7 @@ describe("CalculatorForm", () => {
         regionId: "aws-us-east-1",
         termYears: 1,
         capacityTiB: 8,
+        excludeEgress: false,
       });
     });
 
@@ -122,6 +125,76 @@ describe("CalculatorForm", () => {
 
     const form = screen.getByRole("form", { name: /vault pricing inputs/i });
     expect(form.className).not.toMatch(/lg:grid-cols-\[/);
+  });
+
+  describe("EgressToggle integration", () => {
+    it("renders the egress toggle in the form", () => {
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(<CalculatorForm onInputsChange={vi.fn()} />);
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+    });
+
+    it("toggle is off by default", () => {
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(<CalculatorForm onInputsChange={vi.fn()} />);
+      expect(screen.getByRole("switch")).toHaveAttribute(
+        "aria-checked",
+        "false",
+      );
+    });
+
+    it("includes excludeEgress: true in inputs when toggle is on", async () => {
+      const onInputsChange = vi.fn();
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(<CalculatorForm onInputsChange={onInputsChange} />);
+
+      fireEvent.click(
+        screen.getByRole("combobox", { name: /select a region/i }),
+      );
+      fireEvent.click(
+        screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
+      );
+      fireEvent.change(screen.getByLabelText(/protected capacity/i), {
+        target: { value: "8" },
+      });
+      fireEvent.click(screen.getByRole("switch"));
+
+      await waitFor(() => {
+        expect(onInputsChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({ excludeEgress: true }),
+        );
+      });
+    });
+
+    it("pre-populates excludeEgress: true from initialValues", () => {
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(
+        <CalculatorForm
+          onInputsChange={vi.fn()}
+          initialValues={{ excludeEgress: true }}
+        />,
+      );
+      expect(screen.getByRole("switch")).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+    });
   });
 
   describe("initialValues pre-population", () => {

--- a/src/__tests__/comparison-engine.test.ts
+++ b/src/__tests__/comparison-engine.test.ts
@@ -242,6 +242,65 @@ describe("buildComparison", () => {
     });
   });
 
+  describe("excludeEgress option", () => {
+    const baseInputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 10,
+    };
+
+    it("sets internetEgress to 0 on diyOption1 when excludeEgress is true", () => {
+      const result = buildComparison(
+        { ...baseInputs, excludeEgress: true },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(result.diyOption1.internetEgress).toBe(0);
+    });
+
+    it("sets internetEgress to 0 on diyOption2 when excludeEgress is true", () => {
+      const result = buildComparison(
+        { ...baseInputs, excludeEgress: true },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(result.diyOption2.internetEgress).toBe(0);
+    });
+
+    it("diyOption1 total is lower than with egress included", () => {
+      const excluded = buildComparison(
+        { ...baseInputs, excludeEgress: true },
+        coreRegion,
+        awsStandardPricing,
+      );
+      const included = buildComparison(
+        { ...baseInputs, excludeEgress: false },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(excluded.diyOption1.total).toBeLessThan(included.diyOption1.total);
+    });
+
+    it("does not affect vault totals when excludeEgress is true", () => {
+      const withExclusion = buildComparison(
+        { ...baseInputs, excludeEgress: true },
+        coreRegion,
+        awsStandardPricing,
+      );
+      const withoutExclusion = buildComparison(
+        { ...baseInputs, excludeEgress: false },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(withExclusion.vaultFoundation.total).toBe(
+        withoutExclusion.vaultFoundation.total,
+      );
+      expect(withExclusion.vaultAdvanced.total).toBe(
+        withoutExclusion.vaultAdvanced.total,
+      );
+    });
+  });
+
   describe("Advanced-only region", () => {
     const inputs: CalculatorInputs = {
       regionId: "aws-il-central-1",

--- a/src/__tests__/cost-breakdown-table.test.tsx
+++ b/src/__tests__/cost-breakdown-table.test.tsx
@@ -69,6 +69,36 @@ describe("CostBreakdownTable", () => {
     expect(naInFooter.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("shows 'Internet Egress (excluded)' when excludeEgress is true", () => {
+    render(
+      <CostBreakdownTable
+        comparison={{
+          ...fixtureComparison,
+          diyOption1: { ...fixtureComparison.diyOption1, internetEgress: 0 },
+          diyOption2: { ...fixtureComparison.diyOption2, internetEgress: 0 },
+        }}
+        excludeEgress={true}
+      />,
+    );
+    expect(screen.getByText("Internet Egress (excluded)")).toBeInTheDocument();
+    expect(screen.queryByText("Internet Egress")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Internet Egress' (no suffix) when excludeEgress is false", () => {
+    render(
+      <CostBreakdownTable
+        comparison={fixtureComparison}
+        excludeEgress={false}
+      />,
+    );
+    expect(screen.getByText("Internet Egress")).toBeInTheDocument();
+  });
+
+  it("shows 'Internet Egress' when excludeEgress is omitted", () => {
+    render(<CostBreakdownTable comparison={fixtureComparison} />);
+    expect(screen.getByText("Internet Egress")).toBeInTheDocument();
+  });
+
   it("shows N/A and TBD in vault totals when editions are unavailable", () => {
     const { container } = render(
       <CostBreakdownTable

--- a/src/__tests__/diy-calculator.test.ts
+++ b/src/__tests__/diy-calculator.test.ts
@@ -117,3 +117,54 @@ describe("calculateDiyCost", () => {
     expect(result.storage).toBeCloseTo(8478.72, 4);
   });
 });
+
+describe("calculateDiyCost with excludeEgress option", () => {
+  const pricing: CloudStoragePricing = {
+    storagePerGbMonth: 0.023,
+    writeOpsCost: 0.005,
+    readOpsCost: 0.0004,
+    opsBatchSize: 1000,
+    retrievalPerGb: 0,
+    egressPerGb: 0.09,
+  };
+
+  it("returns internetEgress of 0 when excludeEgress is true", () => {
+    const result = calculateDiyCost(10, 3, pricing, { excludeEgress: true });
+    expect(result.internetEgress).toBe(0);
+  });
+
+  it("total excludes egress when excludeEgress is true", () => {
+    const withEgress = calculateDiyCost(10, 3, pricing);
+    const withoutEgress = calculateDiyCost(10, 3, pricing, {
+      excludeEgress: true,
+    });
+    expect(withoutEgress.total).toBeCloseTo(
+      withEgress.total - withEgress.internetEgress,
+      10,
+    );
+  });
+
+  it("total still equals sum of all five components when excludeEgress is true", () => {
+    const result = calculateDiyCost(10, 3, pricing, { excludeEgress: true });
+    const sum =
+      result.storage +
+      result.writeOps +
+      result.readOps +
+      result.dataRetrieval +
+      result.internetEgress;
+    expect(result.total).toBeCloseTo(sum, 10);
+  });
+
+  it("behaves identically to the default when excludeEgress is false", () => {
+    const withFlag = calculateDiyCost(10, 3, pricing, { excludeEgress: false });
+    const withoutFlag = calculateDiyCost(10, 3, pricing);
+    expect(withFlag.internetEgress).toBeCloseTo(withoutFlag.internetEgress, 10);
+    expect(withFlag.total).toBeCloseTo(withoutFlag.total, 10);
+  });
+
+  it("behaves identically to the default when options are omitted", () => {
+    const explicit = calculateDiyCost(10, 3, pricing, {});
+    const implicit = calculateDiyCost(10, 3, pricing);
+    expect(explicit.total).toBeCloseTo(implicit.total, 10);
+  });
+});

--- a/src/__tests__/egress-toggle.test.tsx
+++ b/src/__tests__/egress-toggle.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EgressToggle } from "@/components/calculator/egress-toggle";
+
+describe("EgressToggle", () => {
+  it("renders a switch with role 'switch'", () => {
+    render(<EgressToggle checked={false} onCheckedChange={vi.fn()} />);
+    expect(screen.getByRole("switch")).toBeInTheDocument();
+  });
+
+  it("is unchecked when checked=false", () => {
+    render(<EgressToggle checked={false} onCheckedChange={vi.fn()} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("is checked when checked=true", () => {
+    render(<EgressToggle checked={true} onCheckedChange={vi.fn()} />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("calls onCheckedChange with true when toggled from off", () => {
+    const onCheckedChange = vi.fn();
+    render(<EgressToggle checked={false} onCheckedChange={onCheckedChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("calls onCheckedChange with false when toggled from on", () => {
+    const onCheckedChange = vi.fn();
+    render(<EgressToggle checked={true} onCheckedChange={onCheckedChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onCheckedChange).toHaveBeenCalledWith(false);
+  });
+
+  it("has an accessible label linked to the switch", () => {
+    render(<EgressToggle checked={false} onCheckedChange={vi.fn()} />);
+    const label = screen.getByText(/exclude internet egress/i);
+    expect(label).toBeInTheDocument();
+    expect(label.tagName.toLowerCase()).toBe("label");
+  });
+
+  it("has a visible description text", () => {
+    render(<EgressToggle checked={false} onCheckedChange={vi.fn()} />);
+    expect(
+      screen.getByText(/expressroute or directconnect/i),
+    ).toBeInTheDocument();
+  });
+
+  it("has no bare animation classes (motion-safe required)", () => {
+    const { container } = render(
+      <EgressToggle checked={false} onCheckedChange={vi.fn()} />,
+    );
+    const allClasses = Array.from(container.querySelectorAll("*"))
+      .flatMap((el) => Array.from(el.classList))
+      .join(" ");
+    const bareAnimations = /(?<!\S)(animate-|fade-|zoom-|slide-)[a-z]/g;
+    expect(allClasses.match(bareAnimations)).toBeNull();
+  });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -22,14 +22,15 @@ class ResizeObserverMock {
   }
 
   observe(target: Element) {
+    const boxSize: ResizeObserverSize = { inlineSize: 960, blockSize: 320 };
     this.callback(
       [
         {
           target,
           contentRect: DEFAULT_RECT,
-          borderBoxSize: [],
-          contentBoxSize: [],
-          devicePixelContentBoxSize: [],
+          borderBoxSize: [boxSize],
+          contentBoxSize: [boxSize],
+          devicePixelContentBoxSize: [boxSize],
         } as ResizeObserverEntry,
       ],
       this as unknown as ResizeObserver,

--- a/src/__tests__/url-params.test.ts
+++ b/src/__tests__/url-params.test.ts
@@ -85,6 +85,28 @@ describe("parseUrlParams", () => {
     const result = parseUrlParams("?region=aws-us-east-1&foo=bar&term=2");
     expect(result).toEqual({ regionId: "aws-us-east-1", termYears: 2 });
   });
+
+  it("parses egress=0 as excludeEgress: true", () => {
+    const result = parseUrlParams(
+      "?region=aws-us-east-1&term=3&capacity=50&egress=0",
+    );
+    expect(result.excludeEgress).toBe(true);
+  });
+
+  it("omits excludeEgress when egress param is absent", () => {
+    const result = parseUrlParams("?region=aws-us-east-1&term=3&capacity=50");
+    expect(result).not.toHaveProperty("excludeEgress");
+  });
+
+  it("omits excludeEgress when egress=1 (egress included)", () => {
+    const result = parseUrlParams("?egress=1");
+    expect(result).not.toHaveProperty("excludeEgress");
+  });
+
+  it("ignores invalid egress param values", () => {
+    const result = parseUrlParams("?egress=true");
+    expect(result).not.toHaveProperty("excludeEgress");
+  });
 });
 
 describe("serialiseUrlParams", () => {
@@ -118,5 +140,45 @@ describe("serialiseUrlParams", () => {
     };
     const result = parseUrlParams("?" + serialiseUrlParams(inputs));
     expect(result).toEqual(inputs);
+  });
+
+  it("includes egress=0 when excludeEgress is true", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 50,
+      excludeEgress: true,
+    };
+    expect(serialiseUrlParams(inputs)).toContain("egress=0");
+  });
+
+  it("omits egress param when excludeEgress is false", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 50,
+      excludeEgress: false,
+    };
+    expect(serialiseUrlParams(inputs)).not.toContain("egress");
+  });
+
+  it("omits egress param when excludeEgress is absent", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 50,
+    };
+    expect(serialiseUrlParams(inputs)).not.toContain("egress");
+  });
+
+  it("round-trips excludeEgress: true through parseUrlParams", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-eu-west-1",
+      termYears: 5,
+      capacityTiB: 250,
+      excludeEgress: true,
+    };
+    const result = parseUrlParams("?" + serialiseUrlParams(inputs));
+    expect(result.excludeEgress).toBe(true);
   });
 });

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { CapacityInput } from "@/components/calculator/capacity-input";
+import { EgressToggle } from "@/components/calculator/egress-toggle";
 import { RegionSelector } from "@/components/calculator/region-selector";
 import { TermSelector } from "@/components/calculator/term-selector";
 import {
@@ -35,6 +36,9 @@ export function CalculatorForm({
   const [capacityTiB, setCapacityTiB] = useState(
     initialValues?.capacityTiB ?? 0,
   );
+  const [excludeEgress, setExcludeEgress] = useState(
+    initialValues?.excludeEgress ?? false,
+  );
 
   // Before the user makes an explicit choice, derive the region from initialValues.
   // After user interaction, userHasSelected takes precedence.
@@ -65,8 +69,9 @@ export function CalculatorForm({
       regionId: selectedRegion.id,
       termYears,
       capacityTiB,
+      excludeEgress,
     };
-  }, [capacityTiB, selectedRegion, termYears]);
+  }, [capacityTiB, excludeEgress, selectedRegion, termYears]);
 
   useEffect(() => {
     onInputsChange(completeInputs);
@@ -101,6 +106,12 @@ export function CalculatorForm({
             value={capacityTiB}
             onCapacityChange={setCapacityTiB}
           />
+          <div className="lg:col-span-2">
+            <EgressToggle
+              checked={excludeEgress}
+              onCheckedChange={setExcludeEgress}
+            />
+          </div>
         </form>
       </CardContent>
     </Card>

--- a/src/components/calculator/egress-toggle.tsx
+++ b/src/components/calculator/egress-toggle.tsx
@@ -1,0 +1,32 @@
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface EgressToggleProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export function EgressToggle({ checked, onCheckedChange }: EgressToggleProps) {
+  return (
+    <div className="border-border/70 flex items-start gap-3 rounded-2xl border bg-[color:var(--card-tint-neutral)]/70 p-4">
+      <Switch
+        id="exclude-egress"
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        aria-describedby="exclude-egress-description"
+      />
+      <div className="grid gap-1">
+        <Label htmlFor="exclude-egress" className="cursor-pointer leading-none">
+          Exclude internet egress
+        </Label>
+        <p
+          id="exclude-egress-description"
+          className="text-muted-foreground text-sm leading-snug"
+        >
+          For ExpressRoute or DirectConnect customers with no internet egress
+          charges.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -26,6 +26,7 @@ import type { ComparisonResult, VaultCostResult } from "@/types/calculator";
 
 interface CostBreakdownTableProps {
   comparison: ComparisonResult;
+  excludeEgress?: boolean;
 }
 
 interface BreakdownRow {
@@ -44,7 +45,10 @@ function formatVaultTotal(result: VaultCostResult): string {
   return formatUSD(result.total);
 }
 
-export function CostBreakdownTable({ comparison }: CostBreakdownTableProps) {
+export function CostBreakdownTable({
+  comparison,
+  excludeEgress,
+}: CostBreakdownTableProps) {
   const fmt1 = (val: number) =>
     comparison.diyOption1Unavailable ? "N/A" : formatUSD(val);
 
@@ -78,7 +82,9 @@ export function CostBreakdownTable({ comparison }: CostBreakdownTableProps) {
       diyOption2: formatUSD(comparison.diyOption2.dataRetrieval),
     },
     {
-      category: "Internet Egress",
+      category: excludeEgress
+        ? "Internet Egress (excluded)"
+        : "Internet Egress",
       foundation: "--",
       advanced: "--",
       diyOption1: fmt1(comparison.diyOption1.internetEgress),

--- a/src/components/results/results-panel.tsx
+++ b/src/components/results/results-panel.tsx
@@ -13,12 +13,14 @@ interface ResultsPanelProps {
   comparison: ComparisonResult | null;
   capacityTiB: number;
   termYears: number;
+  excludeEgress?: boolean;
 }
 
 export function ResultsPanel({
   comparison,
   capacityTiB,
   termYears,
+  excludeEgress,
 }: ResultsPanelProps) {
   const [activeTab, setActiveTab] = useState("overview");
 
@@ -71,7 +73,10 @@ export function ResultsPanel({
         </TabsContent>
 
         <TabsContent value="breakdown" className="space-y-4">
-          <CostBreakdownTable comparison={comparison} />
+          <CostBreakdownTable
+            comparison={comparison}
+            excludeEgress={excludeEgress}
+          />
           <Assumptions />
         </TabsContent>
       </Tabs>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-xs",
+        "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80 data-[state=checked]:bg-[color:var(--viridis)]",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background pointer-events-none block size-4 rounded-full shadow-lg ring-0",
+          "transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/lib/comparison-engine.ts
+++ b/src/lib/comparison-engine.ts
@@ -36,7 +36,8 @@ export function buildComparison(
   region: Region,
   cloudPricing: RegionCloudPricing,
 ): ComparisonResult {
-  const { capacityTiB, termYears } = inputs;
+  const { capacityTiB, termYears, excludeEgress } = inputs;
+  const egressOptions = { excludeEgress: excludeEgress === true };
 
   const foundationService = region.services.vdc_vault.find(
     (s) => s.edition === "Foundation",
@@ -67,12 +68,18 @@ export function buildComparison(
 
   const diyOption1 = cloudPricing.option1Unavailable
     ? ZERO_BREAKDOWN
-    : calculateDiyCost(capacityTiB, termYears, cloudPricing.option1);
+    : calculateDiyCost(
+        capacityTiB,
+        termYears,
+        cloudPricing.option1,
+        egressOptions,
+      );
 
   const diyOption2 = calculateDiyCost(
     capacityTiB,
     termYears,
     cloudPricing.option2,
+    egressOptions,
   );
 
   return {

--- a/src/lib/diy-calculator.ts
+++ b/src/lib/diy-calculator.ts
@@ -72,12 +72,18 @@ export function calculateEgressCost(
   return capacityTiB * TIB_TO_GB * ANNUAL_EGRESS_FACTOR * ratePerGb * termYears;
 }
 
+interface DiyCostOptions {
+  excludeEgress?: boolean;
+}
+
 /** Compute all DIY cost components and their total. */
 export function calculateDiyCost(
   capacityTiB: number,
   termYears: number,
   pricing: CloudStoragePricing,
+  options: DiyCostOptions = {},
 ): CostBreakdown {
+  const { excludeEgress = false } = options;
   const termMonths = termYears * MONTHS_PER_YEAR;
 
   const storage = calculateStorageCost(
@@ -102,11 +108,9 @@ export function calculateDiyCost(
     pricing.retrievalPerGb,
     termYears,
   );
-  const internetEgress = calculateEgressCost(
-    capacityTiB,
-    pricing.egressPerGb,
-    termYears,
-  );
+  const internetEgress = excludeEgress
+    ? 0
+    : calculateEgressCost(capacityTiB, pricing.egressPerGb, termYears);
 
   const total = storage + writeOps + readOps + dataRetrieval + internetEgress;
 

--- a/src/lib/url-params.ts
+++ b/src/lib/url-params.ts
@@ -29,6 +29,10 @@ export function parseUrlParams(search: string): Partial<CalculatorInputs> {
     }
   }
 
+  if (params.get("egress") === "0") {
+    result.excludeEgress = true;
+  }
+
   return result;
 }
 
@@ -37,5 +41,8 @@ export function serialiseUrlParams(inputs: CalculatorInputs): string {
   params.set("region", inputs.regionId);
   params.set("term", String(inputs.termYears));
   params.set("capacity", String(inputs.capacityTiB));
+  if (inputs.excludeEgress === true) {
+    params.set("egress", "0");
+  }
   return params.toString();
 }

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -2,6 +2,7 @@ export interface CalculatorInputs {
   regionId: string;
   termYears: number;
   capacityTiB: number;
+  excludeEgress?: boolean;
 }
 
 export interface CostBreakdown {


### PR DESCRIPTION
## Summary

- Adds a toggle in the calculator form to zero internet egress costs for ExpressRoute/DirectConnect customers
- When enabled, both DIY option breakdowns show $0 for internet egress and the cost breakdown table labels the row "Internet Egress (excluded)"
- Toggle state persists in the share URL via `egress=0` param so shared links preserve the setting

## Changes

- `CalculatorInputs` extended with `excludeEgress?: boolean`
- `calculateDiyCost` gains an optional `options` param — zeroes egress at the calculation layer so `CostBreakdown.total` stays internally consistent
- `buildComparison` extracts and threads `excludeEgress` to both DIY calc calls
- `url-params.ts` parses `egress=0` → `excludeEgress: true` and serialises it back
- New `Switch` UI primitive wrapping Radix, following the project's `label.tsx` pattern
- New `EgressToggle` component (Switch + Label + description) placed full-width below the term/capacity row
- `CostBreakdownTable` accepts `excludeEgress` prop and conditionally suffixes the row label
- `ResultsPanel` and `App.tsx` thread the prop through
- `ResizeObserver` mock in test setup updated with `inlineSize`/`blockSize` to support the Radix Switch component

## Test plan

- [x] 206 tests passing (`npm run test:run`)
- [x] Lint clean (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [x] Toggle visible in form below term/capacity row
- [x] Enabling toggle drops DIY totals and shows "Internet Egress (excluded)" in breakdown tab
- [x] Share URL includes `egress=0` when toggle is on; pasting URL in new tab pre-populates toggle as on
- [x] Disabling toggle restores egress costs and removes URL param

🤖 Generated with [Claude Code](https://claude.com/claude-code)