### PR TITLE
fix(ci): correct Cloudflare Pages project name to vdc-vault-price-calculator

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,5 +23,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./dist --project-name=vdc-vault-tco-calculator --branch=main
+          command: pages deploy ./dist --project-name=vdc-vault-price-calculator --branch=main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,5 +39,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./dist --project-name=vdc-vault-tco-calculator --branch=main
+          command: pages deploy ./dist --project-name=vdc-vault-price-calculator --branch=main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Both `release.yml` and `publish.yml` referenced `--project-name=vdc-vault-tco-calculator`, which no longer exists in Cloudflare Pages
- Updated to the correct project name: `vdc-vault-price-calculator`
- Fixes CI run `24219347851` failure: `8000007 - Project not found`

## Test plan

- [ ] Confirm CI (lint + test) passes on this PR
- [ ] After merge, trigger a release or run the manual `publish.yml` workflow to verify the deploy step resolves successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)