### PR TITLE
fix(calculator): prevent Enter key from clearing inputs

### DIFF
--- a/src/__tests__/calculator-form.test.tsx
+++ b/src/__tests__/calculator-form.test.tsx
@@ -114,6 +114,42 @@ describe("CalculatorForm", () => {
     });
   });
 
+  it("pressing Enter in the capacity input does not clear inputs", async () => {
+    const onInputsChange = vi.fn();
+    vi.mocked(useRegions).mockReturnValue({
+      regions,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<CalculatorForm onInputsChange={onInputsChange} />);
+
+    fireEvent.click(screen.getByRole("combobox", { name: /select a region/i }));
+    fireEvent.click(
+      screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
+    );
+    const capacityInput = screen.getByLabelText(/protected capacity/i);
+    fireEvent.change(capacityInput, { target: { value: "8" } });
+
+    await waitFor(() => {
+      expect(onInputsChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ capacityTiB: 8 }),
+      );
+    });
+
+    // Simulate Enter in the capacity input
+    fireEvent.keyDown(capacityInput, { key: "Enter", code: "Enter" });
+    fireEvent.submit(capacityInput.closest("form")!);
+
+    // Inputs must remain populated — no reset
+    await waitFor(() => {
+      expect(onInputsChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ capacityTiB: 8 }),
+      );
+    });
+    expect(capacityInput).toHaveValue(8);
+  });
+
   it("avoids the rigid custom lg grid that causes laptop-width overlap", () => {
     vi.mocked(useRegions).mockReturnValue({
       regions,

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -92,6 +92,7 @@ export function CalculatorForm({
         <form
           aria-label="Vault pricing inputs"
           className="grid gap-5 lg:grid-cols-2 lg:items-start"
+          onSubmit={(e) => e.preventDefault()}
         >
           <div className="lg:col-span-2">
             <RegionSelector


### PR DESCRIPTION
## Summary

- Adds `onSubmit={(e) => e.preventDefault()}` to the calculator `<form>` element in `calculator-form.tsx`
- Pressing Enter while focused on any input no longer triggers browser default form submission, which was resetting all React state
- Adds a regression test that simulates form submission after inputs are populated and asserts they remain intact

Closes #25

## Test plan

- [x] `npm run test:run` — all 207 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [ ] Manual: select a region, enter a capacity, Tab to the capacity field, press Enter — inputs stay populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)