### PR TITLE
fix(results): prevent render loop on Breakdown tab when term changes

### DIFF
--- a/src/__tests__/cost-breakdown-table.test.tsx
+++ b/src/__tests__/cost-breakdown-table.test.tsx
@@ -99,6 +99,18 @@ describe("CostBreakdownTable", () => {
     expect(screen.getByText("Internet Egress")).toBeInTheDocument();
   });
 
+  it("does not cause a render loop when comparison prop changes (term change regression)", () => {
+    const { rerender } = render(
+      <CostBreakdownTable comparison={fixtureComparison} />,
+    );
+    const updatedComparison = {
+      ...fixtureComparison,
+      vaultFoundation: { ...fixtureComparison.vaultFoundation, total: 9999 },
+    };
+    rerender(<CostBreakdownTable comparison={updatedComparison} />);
+    expect(screen.getByRole("table")).toBeInTheDocument();
+  });
+
   it("shows N/A and TBD in vault totals when editions are unavailable", () => {
     const { container } = render(
       <CostBreakdownTable

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -4,6 +4,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { useMemo } from "react";
 
 import {
   Card,
@@ -38,6 +39,7 @@ interface BreakdownRow {
 }
 
 const columnHelper = createColumnHelper<BreakdownRow>();
+const coreRowModel = getCoreRowModel();
 
 function formatVaultTotal(result: VaultCostResult): string {
   if (result.pricingTbd) return "TBD";
@@ -49,79 +51,84 @@ export function CostBreakdownTable({
   comparison,
   excludeEgress,
 }: CostBreakdownTableProps) {
-  const fmt1 = (val: number) =>
-    comparison.diyOption1Unavailable ? "N/A" : formatUSD(val);
+  const data = useMemo<BreakdownRow[]>(() => {
+    const fmt1 = (val: number) =>
+      comparison.diyOption1Unavailable ? "N/A" : formatUSD(val);
 
-  const data: BreakdownRow[] = [
-    {
-      category: "Storage",
-      foundation: formatVaultTotal(comparison.vaultFoundation),
-      advanced: formatVaultTotal(comparison.vaultAdvanced),
-      diyOption1: fmt1(comparison.diyOption1.storage),
-      diyOption2: formatUSD(comparison.diyOption2.storage),
-    },
-    {
-      category: "Write Operations",
-      foundation: "--",
-      advanced: "--",
-      diyOption1: fmt1(comparison.diyOption1.writeOps),
-      diyOption2: formatUSD(comparison.diyOption2.writeOps),
-    },
-    {
-      category: "Read Operations",
-      foundation: "--",
-      advanced: "--",
-      diyOption1: fmt1(comparison.diyOption1.readOps),
-      diyOption2: formatUSD(comparison.diyOption2.readOps),
-    },
-    {
-      category: "Data Retrieval",
-      foundation: "--",
-      advanced: "--",
-      diyOption1: fmt1(comparison.diyOption1.dataRetrieval),
-      diyOption2: formatUSD(comparison.diyOption2.dataRetrieval),
-    },
-    {
-      category: excludeEgress
-        ? "Internet Egress (excluded)"
-        : "Internet Egress",
-      foundation: "--",
-      advanced: "--",
-      diyOption1: fmt1(comparison.diyOption1.internetEgress),
-      diyOption2: formatUSD(comparison.diyOption2.internetEgress),
-    },
-  ];
+    return [
+      {
+        category: "Storage",
+        foundation: formatVaultTotal(comparison.vaultFoundation),
+        advanced: formatVaultTotal(comparison.vaultAdvanced),
+        diyOption1: fmt1(comparison.diyOption1.storage),
+        diyOption2: formatUSD(comparison.diyOption2.storage),
+      },
+      {
+        category: "Write Operations",
+        foundation: "--",
+        advanced: "--",
+        diyOption1: fmt1(comparison.diyOption1.writeOps),
+        diyOption2: formatUSD(comparison.diyOption2.writeOps),
+      },
+      {
+        category: "Read Operations",
+        foundation: "--",
+        advanced: "--",
+        diyOption1: fmt1(comparison.diyOption1.readOps),
+        diyOption2: formatUSD(comparison.diyOption2.readOps),
+      },
+      {
+        category: "Data Retrieval",
+        foundation: "--",
+        advanced: "--",
+        diyOption1: fmt1(comparison.diyOption1.dataRetrieval),
+        diyOption2: formatUSD(comparison.diyOption2.dataRetrieval),
+      },
+      {
+        category: excludeEgress
+          ? "Internet Egress (excluded)"
+          : "Internet Egress",
+        foundation: "--",
+        advanced: "--",
+        diyOption1: fmt1(comparison.diyOption1.internetEgress),
+        diyOption2: formatUSD(comparison.diyOption2.internetEgress),
+      },
+    ];
+  }, [comparison, excludeEgress]);
 
-  const columns = [
-    columnHelper.accessor("category", {
-      header: "Category",
-      footer: "Total",
-    }),
-    columnHelper.accessor("foundation", {
-      header: "VDC Foundation",
-      footer: formatVaultTotal(comparison.vaultFoundation),
-    }),
-    columnHelper.accessor("advanced", {
-      header: "VDC Advanced",
-      footer: formatVaultTotal(comparison.vaultAdvanced),
-    }),
-    columnHelper.accessor("diyOption1", {
-      header: comparison.diyOption1Label,
-      footer: comparison.diyOption1Unavailable
-        ? "N/A"
-        : formatUSD(comparison.diyOption1.total),
-    }),
-    columnHelper.accessor("diyOption2", {
-      header: comparison.diyOption2Label,
-      footer: formatUSD(comparison.diyOption2.total),
-    }),
-  ];
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor("category", {
+        header: "Category",
+        footer: "Total",
+      }),
+      columnHelper.accessor("foundation", {
+        header: "VDC Foundation",
+        footer: formatVaultTotal(comparison.vaultFoundation),
+      }),
+      columnHelper.accessor("advanced", {
+        header: "VDC Advanced",
+        footer: formatVaultTotal(comparison.vaultAdvanced),
+      }),
+      columnHelper.accessor("diyOption1", {
+        header: comparison.diyOption1Label,
+        footer: comparison.diyOption1Unavailable
+          ? "N/A"
+          : formatUSD(comparison.diyOption1.total),
+      }),
+      columnHelper.accessor("diyOption2", {
+        header: comparison.diyOption2Label,
+        footer: formatUSD(comparison.diyOption2.total),
+      }),
+    ],
+    [comparison],
+  );
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data,
     columns,
-    getCoreRowModel: getCoreRowModel(),
+    getCoreRowModel: coreRowModel,
   });
 
   return (


### PR DESCRIPTION
## Summary

- `CostBreakdownTable` was creating new `data`, `columns`, and `getCoreRowModel()` references on every render
- TanStack Table v8 uses `Object.is` comparison internally; receiving new references each render dispatched internal state updates → re-render → new references → infinite loop → page freeze
- The loop only triggered on the Breakdown tab (where `CostBreakdownTable` is mounted) and was most commonly hit when changing the term input

## Changes

- Memoized `data` with `useMemo` (deps: `comparison`, `excludeEgress`)
- Memoized `columns` with `useMemo` (deps: `comparison`)
- Hoisted `getCoreRowModel()` to module scope so it's created once
- Added regression test: rerender with a new `comparison` object (simulating a term change) completes without freezing

## Test plan

- [x] `npm run test:run` — 208 tests pass
- [x] `npm run lint` — lint clean
- [x] `npm run build` — build succeeds
- [x] Manual: open `?region=aws-ap-east-2&term=1&capacity=10`, switch to Breakdown tab, change term — page stays responsive

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)