### PR TITLE
feat(results): add multi-year cost trend line chart

### DIFF
--- a/src/__tests__/cost-trend-chart.test.tsx
+++ b/src/__tests__/cost-trend-chart.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { fixtureComparison } from "@/__tests__/fixtures/comparison-result";
+import { CostTrendChart } from "@/components/results/cost-trend-chart";
+
+describe("CostTrendChart", () => {
+  it("renders an accessible responsive line chart for a multi-year term", () => {
+    const { container } = render(
+      <CostTrendChart comparison={fixtureComparison} termYears={3} />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: /cumulative cost over 3 years/i }),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".recharts-responsive-container"),
+    ).not.toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("shows legend labels for all available options", () => {
+    render(<CostTrendChart comparison={fixtureComparison} termYears={3} />);
+
+    expect(screen.getAllByText("VDC Vault Foundation").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getAllByText("VDC Vault Advanced").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("S3 Standard").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("S3 Infrequent Access").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("omits legend label for unavailable vault foundation option", () => {
+    render(
+      <CostTrendChart
+        comparison={{
+          ...fixtureComparison,
+          vaultFoundation: { total: null, perTbMonth: null, pricingTbd: false },
+        }}
+        termYears={3}
+      />,
+    );
+
+    expect(screen.queryByText("VDC Vault Foundation")).not.toBeInTheDocument();
+    expect(screen.getAllByText("VDC Vault Advanced").length).toBeGreaterThan(0);
+  });
+
+  it("omits legend label for TBD-priced vault advanced option", () => {
+    render(
+      <CostTrendChart
+        comparison={{
+          ...fixtureComparison,
+          vaultAdvanced: { total: null, perTbMonth: null, pricingTbd: true },
+        }}
+        termYears={3}
+      />,
+    );
+
+    expect(screen.queryByText("VDC Vault Advanced")).not.toBeInTheDocument();
+    expect(screen.getAllByText("VDC Vault Foundation").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("omits legend label for unavailable DIY option 1", () => {
+    render(
+      <CostTrendChart
+        comparison={{ ...fixtureComparison, diyOption1Unavailable: true }}
+        termYears={3}
+      />,
+    );
+
+    expect(screen.queryByText("S3 Standard")).not.toBeInTheDocument();
+    expect(screen.getAllByText("S3 Infrequent Access").length).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/src/__tests__/results-panel.test.tsx
+++ b/src/__tests__/results-panel.test.tsx
@@ -7,6 +7,12 @@ import {
 } from "@/__tests__/fixtures/comparison-result";
 import { ResultsPanel } from "@/components/results/results-panel";
 
+vi.mock("@/components/results/cost-trend-chart", () => ({
+  CostTrendChart: () => (
+    <div data-testid="cost-trend-chart">Cost trend chart</div>
+  ),
+}));
+
 vi.mock("@/components/results/summary-cards", () => ({
   SummaryCards: () => <div data-testid="summary-cards">Summary cards</div>,
 }));
@@ -72,6 +78,77 @@ describe("ResultsPanel", () => {
     const usdLabel = screen.getByText("(USD)");
     expect(usdLabel).toBeInTheDocument();
     expect(usdLabel.closest("h2")).toBeInTheDocument();
+  });
+
+  it("shows the Over time tab when termYears > 1", () => {
+    render(
+      <ResultsPanel
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={3}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: /over time/i })).toBeInTheDocument();
+  });
+
+  it("does not show the Over time tab when termYears is 1", () => {
+    render(
+      <ResultsPanel
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={1}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("tab", { name: /over time/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the trend chart when the Over time tab is active", () => {
+    render(
+      <ResultsPanel
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={3}
+      />,
+    );
+
+    const trendTab = screen.getByRole("tab", { name: /over time/i });
+    fireEvent.mouseDown(trendTab);
+    fireEvent.click(trendTab);
+
+    expect(screen.getByTestId("cost-trend-chart")).toBeInTheDocument();
+  });
+
+  it("resets to overview when termYears drops to 1 while on the trend tab", () => {
+    const { rerender } = render(
+      <ResultsPanel
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={3}
+      />,
+    );
+
+    const trendTab = screen.getByRole("tab", { name: /over time/i });
+    fireEvent.mouseDown(trendTab);
+    fireEvent.click(trendTab);
+    expect(screen.getByTestId("cost-trend-chart")).toBeInTheDocument();
+
+    rerender(
+      <ResultsPanel
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={1}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("tab", { name: /over time/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("summary-cards")).toBeInTheDocument();
+    expect(screen.getByTestId("comparison-chart")).toBeInTheDocument();
   });
 
   it("shows the non-core pricing banner when comparison data includes TBD vault totals", () => {

--- a/src/components/results/cost-trend-chart.tsx
+++ b/src/components/results/cost-trend-chart.tsx
@@ -1,0 +1,277 @@
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { formatUSD, formatUSDCompact } from "@/lib/format-utils";
+import type { ComparisonResult } from "@/types/calculator";
+
+interface CostTrendChartProps {
+  comparison: ComparisonResult;
+  termYears: number;
+}
+
+interface TrendDatum {
+  year: number;
+  vaultFoundation?: number;
+  vaultAdvanced?: number;
+  diy1?: number;
+  diy2?: number;
+}
+
+function buildTrendData(
+  comparison: ComparisonResult,
+  termYears: number,
+): TrendDatum[] {
+  return Array.from({ length: termYears }, (_, i) => {
+    const year = i + 1;
+    const fraction = year / termYears;
+    const datum: TrendDatum = { year };
+
+    if (
+      comparison.vaultFoundation.total !== null &&
+      !comparison.vaultFoundation.pricingTbd
+    ) {
+      datum.vaultFoundation = comparison.vaultFoundation.total * fraction;
+    }
+
+    if (
+      comparison.vaultAdvanced.total !== null &&
+      !comparison.vaultAdvanced.pricingTbd
+    ) {
+      datum.vaultAdvanced = comparison.vaultAdvanced.total * fraction;
+    }
+
+    if (!comparison.diyOption1Unavailable) {
+      datum.diy1 = comparison.diyOption1.total * fraction;
+    }
+
+    datum.diy2 = comparison.diyOption2.total * fraction;
+
+    return datum;
+  });
+}
+
+interface LegendItem {
+  name: string;
+  color: string;
+}
+
+function buildLegendItems(comparison: ComparisonResult): LegendItem[] {
+  const items: LegendItem[] = [];
+
+  if (
+    comparison.vaultFoundation.total !== null &&
+    !comparison.vaultFoundation.pricingTbd
+  ) {
+    items.push({ name: "VDC Vault Foundation", color: "var(--success)" });
+  }
+
+  if (
+    comparison.vaultAdvanced.total !== null &&
+    !comparison.vaultAdvanced.pricingTbd
+  ) {
+    items.push({ name: "VDC Vault Advanced", color: "var(--info)" });
+  }
+
+  if (!comparison.diyOption1Unavailable) {
+    items.push({
+      name: comparison.diyOption1Label,
+      color: "var(--color-chart-1)",
+    });
+  }
+
+  items.push({
+    name: comparison.diyOption2Label,
+    color: "var(--color-chart-3)",
+  });
+
+  return items;
+}
+
+interface TooltipEntry {
+  name?: string | number;
+  value?: string | number | readonly (string | number)[];
+  stroke?: string;
+}
+
+function numericValue(value: TooltipEntry["value"]): number {
+  return typeof value === "number" ? value : 0;
+}
+
+function TrendTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: ReadonlyArray<TooltipEntry>;
+  label?: string | number;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const entries = payload.filter((e) => numericValue(e.value) > 0);
+  if (!entries.length) return null;
+
+  return (
+    <div className="border-border/80 bg-card rounded-2xl border p-3 shadow-lg">
+      <p className="text-foreground mb-2 text-sm font-medium">
+        {typeof label === "number" ? `Year ${label}` : String(label ?? "")}
+      </p>
+      <div className="space-y-1">
+        {entries.map((entry) => (
+          <div
+            key={String(entry.name ?? "")}
+            className="flex items-center justify-between gap-6 text-xs"
+          >
+            <span className="text-muted-foreground">
+              {String(entry.name ?? "")}
+            </span>
+            <span
+              className="font-medium [font-variant-numeric:tabular-nums]"
+              style={{ color: entry.stroke }}
+            >
+              {formatUSD(numericValue(entry.value))}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CostTrendChart({ comparison, termYears }: CostTrendChartProps) {
+  const data = buildTrendData(comparison, termYears);
+  const legendItems = buildLegendItems(comparison);
+
+  const showFoundation =
+    comparison.vaultFoundation.total !== null &&
+    !comparison.vaultFoundation.pricingTbd;
+  const showAdvanced =
+    comparison.vaultAdvanced.total !== null &&
+    !comparison.vaultAdvanced.pricingTbd;
+  const showDiy1 = !comparison.diyOption1Unavailable;
+
+  return (
+    <Card className="border-border/70 bg-background/90 rounded-[1.75rem] shadow-[0_32px_100px_-56px_color-mix(in_oklab,var(--electric-azure)_75%,transparent)]">
+      <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
+        <CardTitle className="text-xl tracking-[-0.03em]">
+          Cost over time
+        </CardTitle>
+        <CardDescription>
+          Cumulative spend per option at the end of each year of your{" "}
+          {termYears}-year commitment.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-6">
+        <div
+          role="img"
+          aria-label={`Cumulative cost over ${termYears} years`}
+          className="h-80 w-full"
+        >
+          <ResponsiveContainer
+            width="100%"
+            height="100%"
+            minHeight={320}
+            initialDimension={{ width: 960, height: 320 }}
+          >
+            <LineChart
+              data={data}
+              margin={{ top: 8, right: 8, bottom: 8, left: 0 }}
+            >
+              <CartesianGrid
+                stroke="color-mix(in oklab, var(--border) 80%, transparent)"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="year"
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={(v: number) => `Year ${v}`}
+                tick={{ fill: "var(--color-muted-foreground)", fontSize: 12 }}
+                height={40}
+              />
+              <YAxis
+                axisLine={false}
+                tickLine={false}
+                tickFormatter={(v) => formatUSDCompact(Number(v))}
+                tick={{ fill: "var(--color-muted-foreground)", fontSize: 12 }}
+                width={72}
+              />
+              <Tooltip content={TrendTooltip} />
+              {showFoundation && (
+                <Line
+                  dataKey="vaultFoundation"
+                  name="VDC Vault Foundation"
+                  stroke="var(--success)"
+                  strokeWidth={2}
+                  dot={{ r: 4, fill: "var(--success)" }}
+                  activeDot={{ r: 6 }}
+                  isAnimationActive={false}
+                />
+              )}
+              {showAdvanced && (
+                <Line
+                  dataKey="vaultAdvanced"
+                  name="VDC Vault Advanced"
+                  stroke="var(--info)"
+                  strokeWidth={2}
+                  dot={{ r: 4, fill: "var(--info)" }}
+                  activeDot={{ r: 6 }}
+                  isAnimationActive={false}
+                />
+              )}
+              {showDiy1 && (
+                <Line
+                  dataKey="diy1"
+                  name={comparison.diyOption1Label}
+                  stroke="var(--color-chart-1)"
+                  strokeWidth={2}
+                  dot={{ r: 4, fill: "var(--color-chart-1)" }}
+                  activeDot={{ r: 6 }}
+                  isAnimationActive={false}
+                />
+              )}
+              <Line
+                dataKey="diy2"
+                name={comparison.diyOption2Label}
+                stroke="var(--color-chart-3)"
+                strokeWidth={2}
+                dot={{ r: 4, fill: "var(--color-chart-3)" }}
+                activeDot={{ r: 6 }}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="flex flex-wrap justify-center gap-x-5 gap-y-2 pt-5">
+          {legendItems.map((item) => (
+            <span
+              key={item.name}
+              className="text-muted-foreground flex items-center gap-1.5 text-xs"
+            >
+              <span
+                className="size-2.5 shrink-0 rounded-[3px]"
+                style={{ backgroundColor: item.color }}
+              />
+              {item.name}
+            </span>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/results/results-panel.tsx
+++ b/src/components/results/results-panel.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { BarChart3, LayoutList } from "lucide-react";
+import { BarChart3, LayoutList, TrendingUp } from "lucide-react";
 
 import { Assumptions } from "@/components/results/assumptions";
 import { ComparisonChart } from "@/components/results/comparison-chart";
 import { CostBreakdownTable } from "@/components/results/cost-breakdown-table";
+import { CostTrendChart } from "@/components/results/cost-trend-chart";
 import { NonCoreBanner } from "@/components/results/non-core-banner";
 import { SummaryCards } from "@/components/results/summary-cards";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -23,6 +24,10 @@ export function ResultsPanel({
   excludeEgress,
 }: ResultsPanelProps) {
   const [activeTab, setActiveTab] = useState("overview");
+  const showTrend = termYears > 1;
+  // Derive effective tab: if trend tab is selected but no longer available, fall back to overview.
+  const effectiveTab =
+    !showTrend && activeTab === "trend" ? "overview" : activeTab;
 
   if (comparison === null) {
     return null;
@@ -51,16 +56,22 @@ export function ResultsPanel({
 
       <NonCoreBanner comparison={comparison} />
 
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="gap-4">
+      <Tabs value={effectiveTab} onValueChange={setActiveTab} className="gap-4">
         <TabsList className="border-border/70 bg-background/80 h-auto w-full justify-start rounded-full border p-1">
           <TabsTrigger value="overview" className="rounded-full px-4">
-            <BarChart3 className="size-4" />
+            <BarChart3 className="size-4" aria-hidden="true" />
             Overview
           </TabsTrigger>
           <TabsTrigger value="breakdown" className="rounded-full px-4">
-            <LayoutList className="size-4" />
+            <LayoutList className="size-4" aria-hidden="true" />
             Breakdown
           </TabsTrigger>
+          {showTrend && (
+            <TabsTrigger value="trend" className="rounded-full px-4">
+              <TrendingUp className="size-4" aria-hidden="true" />
+              Over time
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="overview" className="space-y-4">
@@ -79,6 +90,12 @@ export function ResultsPanel({
           />
           <Assumptions />
         </TabsContent>
+
+        {showTrend && (
+          <TabsContent value="trend">
+            <CostTrendChart comparison={comparison} termYears={termYears} />
+          </TabsContent>
+        )}
       </Tabs>
     </section>
   );


### PR DESCRIPTION
## Summary

- Adds a **"Over time"** tab to the results panel that appears only when the selected term is > 1 year, closing #26
- New `CostTrendChart` component renders a Recharts `LineChart` showing cumulative spend per option at the end of each year
- Tab is completely hidden for 1-year terms — no extra scrolling or visual clutter on mobile
- If a user is on the "Over time" tab and changes the term back to 1 year, the active tab gracefully falls back to "Overview" (derived state, no `useEffect`)

## Design decisions

- **Opt-in via tab** rather than stacking another chart on the Overview tab — keeps mobile experience clean and purposeful
- **Derived per-year costs** from existing `ComparisonResult` totals (all costs are linear with time), so no engine changes needed
- `isAnimationActive={false}` on Recharts `Line` components — Recharts doesn't expose a native `prefers-reduced-motion` hook; disabling avoids potential issues without needing a `window.matchMedia` wrapper
- Options with `null` totals (unavailable or TBD-priced) are omitted from the chart and legend

## Test plan

- [x] `npm run test:run` — all 217 tests pass (16 new)
- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds
- [x] Manual: select 1-year term → "Over time" tab absent
- [x] Manual: select 3-year term → "Over time" tab present, line chart shows 3 data points per available option
- [x] Manual: switch to "Over time" tab, change term to 1 year → resets to Overview automatically
- [x] Manual: narrow viewport (mobile width) → chart is responsive, no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)