### PR TITLE
refactor(perf): reduce initial bundle via lazy loading and dep removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@fontsource-variable/syne": "^5.2.7",
         "@tailwindcss/cli": "^4.1.18",
         "@tailwindcss/vite": "^4.1.18",
-        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -4908,39 +4907,6 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
-    "node_modules/@tanstack/react-table": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
-      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/table-core": "8.21.3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@tanstack/table-core": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
-      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@fontsource-variable/syne": "^5.2.7",
     "@tailwindcss/cli": "^4.1.18",
     "@tailwindcss/vite": "^4.1.18",
-    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useMemo, useState } from "react";
 
 import { CalculatorForm } from "@/components/calculator/calculator-form";
 import { SiteFooter } from "@/components/layout/site-footer";
 import { SiteHeader } from "@/components/layout/site-header";
-import { ResultsPanel } from "@/components/results/results-panel";
+
+const ResultsPanel = lazy(async () => {
+  const m = await import("@/components/results/results-panel");
+  return { default: m.ResultsPanel };
+});
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { CLOUD_PRICING } from "@/data/cloud-pricing";
 import { useRegions } from "@/hooks/use-regions";
@@ -74,12 +78,14 @@ function App() {
 
           <div aria-live="polite">
             {comparison !== null && inputs !== null ? (
-              <ResultsPanel
-                comparison={comparison}
-                capacityTiB={inputs.capacityTiB}
-                termYears={inputs.termYears}
-                excludeEgress={inputs.excludeEgress === true}
-              />
+              <Suspense fallback={null}>
+                <ResultsPanel
+                  comparison={comparison}
+                  capacityTiB={inputs.capacityTiB}
+                  termYears={inputs.termYears}
+                  excludeEgress={inputs.excludeEgress === true}
+                />
+              </Suspense>
             ) : null}
           </div>
         </div>

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/hooks/use-regions", () => ({
   useRegions: vi.fn(),
@@ -38,6 +38,14 @@ const defaultUrlState = {
 };
 
 describe("App", () => {
+  beforeAll(async () => {
+    // Pre-load the lazy ResultsPanel module so React.lazy resolves it as an
+    // immediate microtask (synchronously flushable within act()) rather than
+    // waiting for an async module load that may not complete within a single
+    // act() flush when the full test suite runs under load.
+    await import("@/components/results/results-panel");
+  });
+
   beforeEach(() => {
     vi.mocked(useRegions).mockReset();
     vi.mocked(useUrlState).mockReturnValue({

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -1,9 +1,3 @@
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
 import { useMemo } from "react";
 
 import {
@@ -37,9 +31,6 @@ interface BreakdownRow {
   diyOption1: string;
   diyOption2: string;
 }
-
-const columnHelper = createColumnHelper<BreakdownRow>();
-const coreRowModel = getCoreRowModel();
 
 function formatVaultTotal(result: VaultCostResult): string {
   if (result.pricingTbd) return "TBD";
@@ -96,41 +87,6 @@ export function CostBreakdownTable({
     ];
   }, [comparison, excludeEgress]);
 
-  const columns = useMemo(
-    () => [
-      columnHelper.accessor("category", {
-        header: "Category",
-        footer: "Total",
-      }),
-      columnHelper.accessor("foundation", {
-        header: "VDC Foundation",
-        footer: formatVaultTotal(comparison.vaultFoundation),
-      }),
-      columnHelper.accessor("advanced", {
-        header: "VDC Advanced",
-        footer: formatVaultTotal(comparison.vaultAdvanced),
-      }),
-      columnHelper.accessor("diyOption1", {
-        header: comparison.diyOption1Label,
-        footer: comparison.diyOption1Unavailable
-          ? "N/A"
-          : formatUSD(comparison.diyOption1.total),
-      }),
-      columnHelper.accessor("diyOption2", {
-        header: comparison.diyOption2Label,
-        footer: formatUSD(comparison.diyOption2.total),
-      }),
-    ],
-    [comparison],
-  );
-
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const table = useReactTable({
-    data,
-    columns,
-    getCoreRowModel: coreRowModel,
-  });
-
   return (
     <Card className="border-border/70 bg-background/90 rounded-[1.75rem] shadow-[0_32px_100px_-56px_color-mix(in_oklab,var(--electric-azure)_75%,transparent)]">
       <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
@@ -145,47 +101,41 @@ export function CostBreakdownTable({
       <CardContent className="pt-6">
         <Table>
           <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                ))}
-              </TableRow>
-            ))}
+            <TableRow>
+              <TableHead>Category</TableHead>
+              <TableHead>VDC Foundation</TableHead>
+              <TableHead>VDC Advanced</TableHead>
+              <TableHead>{comparison.diyOption1Label}</TableHead>
+              <TableHead>{comparison.diyOption2Label}</TableHead>
+            </TableRow>
           </TableHeader>
           <TableBody>
-            {table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
+            {data.map((row) => (
+              <TableRow key={row.category}>
+                <TableCell>{row.category}</TableCell>
+                <TableCell>{row.foundation}</TableCell>
+                <TableCell>{row.advanced}</TableCell>
+                <TableCell>{row.diyOption1}</TableCell>
+                <TableCell>{row.diyOption2}</TableCell>
               </TableRow>
             ))}
           </TableBody>
           <TableFooter>
-            {table.getFooterGroups().map((footerGroup) => (
-              <TableRow key={footerGroup.id}>
-                {footerGroup.headers.map((header) => (
-                  <TableCell key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.footer,
-                          header.getContext(),
-                        )}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
+            <TableRow>
+              <TableCell>Total</TableCell>
+              <TableCell>
+                {formatVaultTotal(comparison.vaultFoundation)}
+              </TableCell>
+              <TableCell>
+                {formatVaultTotal(comparison.vaultAdvanced)}
+              </TableCell>
+              <TableCell>
+                {comparison.diyOption1Unavailable
+                  ? "N/A"
+                  : formatUSD(comparison.diyOption1.total)}
+              </TableCell>
+              <TableCell>{formatUSD(comparison.diyOption2.total)}</TableCell>
+            </TableRow>
           </TableFooter>
         </Table>
       </CardContent>


### PR DESCRIPTION
## Summary

- Removes `@tanstack/react-table` dependency and replaces the `CostBreakdownTable` implementation with native JSX using existing shadcn `Table` primitives. The library's sorting/filtering/pagination features were unused for this static 5-row table.
- Wraps `ResultsPanel` in `React.lazy` + `Suspense` in `App.tsx`, deferring Recharts and its transitive dependencies (redux, immer, reselect, victory-vendor) until the user's first comparison result is available.

## Before / after

| | Before | After |
|---|---|---|
| Initial JS chunk | 801 kB / **240 kB gz** | 348 kB / **108 kB gz** |
| Results chunk | none (eager) | 404 kB / 120 kB gz (deferred) |
| Vite 500 kB warning | triggered | gone |
| Dependencies removed | — | `@tanstack/react-table` |

## Test plan

- [x] `npm run test:run` — all 217 tests pass (no test logic changes; one `beforeAll` added to `app.test.tsx` to pre-load the lazy module so React.lazy resolves as a microtask when the full suite runs under parallel load)
- [x] `npm run lint` — clean
- [x] `npm run build` — two chunks emitted, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)