### PR TITLE
fix(calculator): rename "Protected capacity" to "Required capacity"

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -90,7 +90,7 @@ describe("App", () => {
       screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
     );
     fireEvent.click(screen.getByRole("radio", { name: /3 years/i }));
-    fireEvent.change(screen.getByLabelText(/protected capacity/i), {
+    fireEvent.change(screen.getByLabelText(/required capacity/i), {
       target: { value: "8" },
     });
 
@@ -180,7 +180,7 @@ describe("App", () => {
     fireEvent.click(
       screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
     );
-    fireEvent.change(screen.getByLabelText(/protected capacity/i), {
+    fireEvent.change(screen.getByLabelText(/required capacity/i), {
       target: { value: "8" },
     });
 

--- a/src/__tests__/calculator-form.test.tsx
+++ b/src/__tests__/calculator-form.test.tsx
@@ -52,7 +52,7 @@ describe("CalculatorForm", () => {
     fireEvent.click(
       screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
     );
-    fireEvent.change(screen.getByLabelText(/protected capacity/i), {
+    fireEvent.change(screen.getByLabelText(/required capacity/i), {
       target: { value: "8" },
     });
 
@@ -91,7 +91,7 @@ describe("CalculatorForm", () => {
     fireEvent.click(
       screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
     );
-    const capacityInput = screen.getByLabelText(/protected capacity/i);
+    const capacityInput = screen.getByLabelText(/required capacity/i);
     fireEvent.change(capacityInput, {
       target: { value: "8" },
     });
@@ -128,7 +128,7 @@ describe("CalculatorForm", () => {
     fireEvent.click(
       screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
     );
-    const capacityInput = screen.getByLabelText(/protected capacity/i);
+    const capacityInput = screen.getByLabelText(/required capacity/i);
     fireEvent.change(capacityInput, { target: { value: "8" } });
 
     await waitFor(() => {
@@ -202,7 +202,7 @@ describe("CalculatorForm", () => {
       fireEvent.click(
         screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
       );
-      fireEvent.change(screen.getByLabelText(/protected capacity/i), {
+      fireEvent.change(screen.getByLabelText(/required capacity/i), {
         target: { value: "8" },
       });
       fireEvent.click(screen.getByRole("switch"));
@@ -249,7 +249,7 @@ describe("CalculatorForm", () => {
       );
 
       expect(screen.getByRole("radio", { name: "3 Years" })).toBeChecked();
-      expect(screen.getByLabelText(/protected capacity/i)).toHaveValue(42);
+      expect(screen.getByLabelText(/required capacity/i)).toHaveValue(42);
     });
 
     it("auto-selects the region matching initialValues.regionId after regions load", async () => {
@@ -309,7 +309,7 @@ describe("CalculatorForm", () => {
 
       expect(screen.getByRole("radio", { name: "5 Years" })).toBeChecked();
       // CapacityInput shows "" (null value) when capacityTiB is 0
-      expect(screen.getByLabelText(/protected capacity/i)).toHaveValue(null);
+      expect(screen.getByLabelText(/required capacity/i)).toHaveValue(null);
     });
   });
 });

--- a/src/__tests__/capacity-input.test.tsx
+++ b/src/__tests__/capacity-input.test.tsx
@@ -6,7 +6,7 @@ describe("CapacityInput", () => {
   it("renders an associated label, TiB suffix, and numeric constraints", () => {
     render(<CapacityInput onCapacityChange={vi.fn()} value={0} />);
 
-    const input = screen.getByLabelText(/protected capacity/i);
+    const input = screen.getByLabelText(/required capacity/i);
     expect(input).toHaveAttribute("min", "1");
     expect(input).toHaveAttribute("step", "1");
     expect(screen.getByText("TiB")).toBeInTheDocument();
@@ -16,7 +16,7 @@ describe("CapacityInput", () => {
     const onCapacityChange = vi.fn();
     render(<CapacityInput onCapacityChange={onCapacityChange} value={0} />);
 
-    const input = screen.getByLabelText(/protected capacity/i);
+    const input = screen.getByLabelText(/required capacity/i);
     fireEvent.change(input, { target: { value: "12" } });
     fireEvent.change(input, { target: { value: "abc" } });
 

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -84,7 +84,7 @@ export function CalculatorForm({
           Calculation inputs
         </CardTitle>
         <CardDescription>
-          Select a region, commitment term, and protected capacity to see a live
+          Select a region, commitment term, and required capacity to see a live
           cost comparison.
         </CardDescription>
       </CardHeader>

--- a/src/components/calculator/capacity-input.tsx
+++ b/src/components/calculator/capacity-input.tsx
@@ -31,7 +31,7 @@ export function CapacityInput({
 
   return (
     <div className="grid gap-2">
-      <Label htmlFor="capacity-tib">Protected capacity</Label>
+      <Label htmlFor="capacity-tib">Required capacity</Label>
       <div className="relative">
         <Input
           id="capacity-tib"

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -37,7 +37,7 @@ export function SiteHeader() {
               <p className="text-muted-foreground max-w-2xl text-sm leading-6 sm:text-base">
                 See the full cost of VDC Vault Foundation and Advanced versus
                 building your own cloud storage — broken down by region, term,
-                and protected capacity.
+                and required capacity.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Renames the label **"Protected capacity"** to **"Required capacity"** across the UI and all test label queries
- The old wording implied the amount of data being protected; the correct framing is the storage capacity required to hold the backups themselves

## Files changed

| File | Change |
|------|--------|
| `src/components/calculator/capacity-input.tsx` | Label text |
| `src/components/layout/site-header.tsx` | Header description |
| `src/components/calculator/calculator-form.tsx` | Card description |
| `src/__tests__/capacity-input.test.tsx` | Label query regex |
| `src/__tests__/app.test.tsx` | Label query regex |
| `src/__tests__/calculator-form.test.tsx` | Label query regex |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 217 tests pass (31 files)
- [x] `npm run build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)