### PR TITLE
feat(calculator): dynamic restore percentage slider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ function App() {
                   capacityTiB={inputs.capacityTiB}
                   termYears={inputs.termYears}
                   excludeEgress={inputs.excludeEgress === true}
+                  restorePercentage={inputs.restorePercentage}
                 />
               </Suspense>
             ) : null}

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -191,6 +191,7 @@ describe("App", () => {
       termYears: 1,
       capacityTiB: 8,
       excludeEgress: false,
+      restorePercentage: 20,
     });
   }, 10_000);
 });

--- a/src/__tests__/assumptions.test.tsx
+++ b/src/__tests__/assumptions.test.tsx
@@ -4,17 +4,35 @@ import { Assumptions } from "@/components/results/assumptions";
 
 describe("Assumptions", () => {
   it("renders a collapsible panel with calculator assumptions", () => {
-    render(<Assumptions />);
+    render(<Assumptions restorePercentage={20} />);
 
     fireEvent.click(
       screen.getByRole("button", { name: /calculation assumptions/i }),
     );
 
     expect(screen.getByText(/1 MB operation size/i)).toBeInTheDocument();
-    expect(screen.getByText(/20% annual read-back/i)).toBeInTheDocument();
-    expect(screen.getByText(/20% annual egress/i)).toBeInTheDocument();
     expect(
       screen.getByText(/published VDC Vault Core pricing/i),
     ).toBeInTheDocument();
+  });
+
+  it("renders the restore percentage from prop", () => {
+    render(<Assumptions restorePercentage={20} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /calculation assumptions/i }),
+    );
+
+    expect(screen.getByText(/20% annual restore/i)).toBeInTheDocument();
+  });
+
+  it("renders a custom restorePercentage", () => {
+    render(<Assumptions restorePercentage={50} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /calculation assumptions/i }),
+    );
+
+    expect(screen.getByText(/50% annual restore/i)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/calculator-form.test.tsx
+++ b/src/__tests__/calculator-form.test.tsx
@@ -62,6 +62,7 @@ describe("CalculatorForm", () => {
         termYears: 1,
         capacityTiB: 8,
         excludeEgress: false,
+        restorePercentage: 20,
       });
     });
 
@@ -73,6 +74,7 @@ describe("CalculatorForm", () => {
         termYears: 3,
         capacityTiB: 8,
         excludeEgress: false,
+        restorePercentage: 20,
       });
     });
   });
@@ -102,6 +104,7 @@ describe("CalculatorForm", () => {
         termYears: 1,
         capacityTiB: 8,
         excludeEgress: false,
+        restorePercentage: 20,
       });
     });
 
@@ -310,6 +313,82 @@ describe("CalculatorForm", () => {
       expect(screen.getByRole("radio", { name: "5 Years" })).toBeChecked();
       // CapacityInput shows "" (null value) when capacityTiB is 0
       expect(screen.getByLabelText(/required capacity/i)).toHaveValue(null);
+    });
+  });
+
+  describe("RestorePercentageSlider integration", () => {
+    it("renders the restore percentage slider in the form", () => {
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(<CalculatorForm onInputsChange={vi.fn()} />);
+      expect(
+        screen.getByRole("slider", { name: /annual restore percentage/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("slider defaults to 20 (percent)", () => {
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(<CalculatorForm onInputsChange={vi.fn()} />);
+      expect(
+        screen.getByRole("slider", { name: /annual restore percentage/i }),
+      ).toHaveAttribute("aria-valuenow", "20");
+    });
+
+    it("pre-populates restorePercentage from initialValues", () => {
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(
+        <CalculatorForm
+          onInputsChange={vi.fn()}
+          initialValues={{ restorePercentage: 50 }}
+        />,
+      );
+      expect(
+        screen.getByRole("slider", { name: /annual restore percentage/i }),
+      ).toHaveAttribute("aria-valuenow", "50");
+    });
+
+    it("includes restorePercentage in onInputsChange when slider moves", async () => {
+      const onInputsChange = vi.fn();
+      vi.mocked(useRegions).mockReturnValue({
+        regions,
+        isLoading: false,
+        error: null,
+      });
+      render(<CalculatorForm onInputsChange={onInputsChange} />);
+
+      // Fill in required inputs first
+      fireEvent.click(
+        screen.getByRole("combobox", { name: /select a region/i }),
+      );
+      fireEvent.click(
+        screen.getByRole("option", { name: /us east \(n\. virginia\)/i }),
+      );
+      fireEvent.change(screen.getByLabelText(/required capacity/i), {
+        target: { value: "10" },
+      });
+
+      // Advance slider
+      const slider = screen.getByRole("slider", {
+        name: /annual restore percentage/i,
+      });
+      fireEvent.keyDown(slider, { key: "ArrowRight" });
+
+      await waitFor(() => {
+        expect(onInputsChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({ restorePercentage: 21 }),
+        );
+      });
     });
   });
 });

--- a/src/__tests__/comparison-engine.test.ts
+++ b/src/__tests__/comparison-engine.test.ts
@@ -109,6 +109,7 @@ describe("buildComparison", () => {
       regionId: "aws-us-east-1",
       termYears: 3,
       capacityTiB: 10,
+      restorePercentage: 20,
     };
 
     it("returns Foundation total of 5040", () => {
@@ -141,6 +142,7 @@ describe("buildComparison", () => {
       regionId: "aws-ap-east-1",
       termYears: 3,
       capacityTiB: 10,
+      restorePercentage: 20,
     };
 
     it("returns Foundation total of 6840 (AWS $19/TB)", () => {
@@ -168,6 +170,7 @@ describe("buildComparison", () => {
       regionId: "azure-eastasia",
       termYears: 3,
       capacityTiB: 10,
+      restorePercentage: 20,
     };
 
     it("returns Foundation total of 8640 (Azure $24/TB)", () => {
@@ -207,6 +210,7 @@ describe("buildComparison", () => {
       regionId: "azure-us-west",
       termYears: 3,
       capacityTiB: 10,
+      restorePercentage: 20,
     };
 
     it("sets diyOption1Unavailable to true", () => {
@@ -247,6 +251,7 @@ describe("buildComparison", () => {
       regionId: "aws-us-east-1",
       termYears: 3,
       capacityTiB: 10,
+      restorePercentage: 20,
     };
 
     it("sets internetEgress to 0 on diyOption1 when excludeEgress is true", () => {
@@ -306,6 +311,7 @@ describe("buildComparison", () => {
       regionId: "aws-il-central-1",
       termYears: 1,
       capacityTiB: 10,
+      restorePercentage: 20,
     };
 
     it("returns null for Foundation (not pricingTbd)", () => {
@@ -325,6 +331,135 @@ describe("buildComparison", () => {
         awsStandardPricing,
       );
       expect(result.vaultAdvanced.total).toBe(2880);
+    });
+  });
+
+  describe("restorePercentage at 20 (default) — no overage", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 10,
+      restorePercentage: 20,
+    };
+
+    it("vaultFoundation.overage is undefined", () => {
+      const result = buildComparison(inputs, coreRegion, awsStandardPricing);
+      expect(result.vaultFoundation.overage).toBeUndefined();
+    });
+
+    it("vaultFoundation.total equals base flat price (5040)", () => {
+      const result = buildComparison(inputs, coreRegion, awsStandardPricing);
+      expect(result.vaultFoundation.total).toBe(5040);
+    });
+  });
+
+  describe("restorePercentage above 20 — Foundation overage applied", () => {
+    const baseInputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 10,
+      restorePercentage: 20,
+    };
+
+    it("vaultFoundation.total exceeds base price when restorePercentage is 50", () => {
+      const at50 = buildComparison(
+        { ...baseInputs, restorePercentage: 50 },
+        coreRegion,
+        awsStandardPricing,
+      );
+      const at20 = buildComparison(baseInputs, coreRegion, awsStandardPricing);
+      expect(at50.vaultFoundation.total).toBeGreaterThan(
+        at20.vaultFoundation.total!,
+      );
+    });
+
+    it("vaultFoundation.overage is defined and positive at 50%", () => {
+      const result = buildComparison(
+        { ...baseInputs, restorePercentage: 50 },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(result.vaultFoundation.overage).toBeDefined();
+      expect(result.vaultFoundation.overage!).toBeGreaterThan(0);
+    });
+
+    it("vaultAdvanced.total is unaffected by restorePercentage (no overage model)", () => {
+      const at20 = buildComparison(baseInputs, coreRegion, awsStandardPricing);
+      const at50 = buildComparison(
+        { ...baseInputs, restorePercentage: 50 },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(at50.vaultAdvanced.total).toBe(at20.vaultAdvanced.total);
+    });
+
+    it("Foundation total = base + overage", () => {
+      const result = buildComparison(
+        { ...baseInputs, restorePercentage: 50 },
+        coreRegion,
+        awsStandardPricing,
+      );
+      const base = 5040; // 10 * $14/TB * 36 months
+      expect(result.vaultFoundation.total).toBeCloseTo(
+        base + result.vaultFoundation.overage!,
+        4,
+      );
+    });
+  });
+
+  describe("excludeEgress suppresses overage egress", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 10,
+      restorePercentage: 50,
+    };
+
+    it("Foundation total is lower with excludeEgress when restorePercentage > 20", () => {
+      const withEgress = buildComparison(
+        { ...inputs, excludeEgress: false },
+        coreRegion,
+        awsStandardPricing,
+      );
+      const withoutEgress = buildComparison(
+        { ...inputs, excludeEgress: true },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(withoutEgress.vaultFoundation.total).toBeLessThan(
+        withEgress.vaultFoundation.total!,
+      );
+    });
+  });
+
+  describe("restorePercentage affects DIY read costs", () => {
+    const baseInputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 10,
+      restorePercentage: 20,
+    };
+
+    it("diyOption1.readOps differs between 20% and 50%", () => {
+      const at20 = buildComparison(baseInputs, coreRegion, awsStandardPricing);
+      const at50 = buildComparison(
+        { ...baseInputs, restorePercentage: 50 },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(at50.diyOption1.readOps).toBeGreaterThan(at20.diyOption1.readOps);
+    });
+
+    it("diyOption2.dataRetrieval differs between 20% and 50%", () => {
+      const at20 = buildComparison(baseInputs, coreRegion, awsStandardPricing);
+      const at50 = buildComparison(
+        { ...baseInputs, restorePercentage: 50 },
+        coreRegion,
+        awsStandardPricing,
+      );
+      expect(at50.diyOption2.dataRetrieval).toBeGreaterThan(
+        at20.diyOption2.dataRetrieval,
+      );
     });
   });
 });

--- a/src/__tests__/cost-breakdown-table.test.tsx
+++ b/src/__tests__/cost-breakdown-table.test.tsx
@@ -169,6 +169,43 @@ describe("CostBreakdownTable", () => {
     expect(screen.getByText("$317.50")).toBeInTheDocument();
   });
 
+  it("storage row shows base cost (total minus overage) when overage is present", () => {
+    // total = 5040 base + 317.5 overage = 5357.5
+    // Storage row should show $5,040.00 (base only); footer Total shows $5,357.50
+    const { container } = render(
+      <CostBreakdownTable
+        comparison={{
+          ...fixtureComparison,
+          vaultFoundation: {
+            ...fixtureComparison.vaultFoundation,
+            total: 5357.5,
+            overage: 317.5,
+          },
+        }}
+      />,
+    );
+
+    const footer = container.querySelector("tfoot");
+    const tbody = container.querySelector("tbody");
+
+    // Storage row in tbody shows base cost
+    const storageRow = Array.from(
+      (tbody as HTMLElement).querySelectorAll("tr"),
+    ).find((row) => row.textContent?.includes("Storage"));
+    expect(storageRow).toBeTruthy();
+    expect(
+      within(storageRow as HTMLElement).getByText("$5,040.00"),
+    ).toBeInTheDocument();
+    expect(
+      within(storageRow as HTMLElement).queryByText("$5,357.50"),
+    ).not.toBeInTheDocument();
+
+    // Footer shows full total including overage
+    expect(
+      within(footer as HTMLElement).getByText("$5,357.50"),
+    ).toBeInTheDocument();
+  });
+
   it("overage row shows '--' for Advanced and DIY columns", () => {
     render(
       <CostBreakdownTable

--- a/src/__tests__/cost-breakdown-table.test.tsx
+++ b/src/__tests__/cost-breakdown-table.test.tsx
@@ -135,4 +135,54 @@ describe("CostBreakdownTable", () => {
     expect(within(footer as HTMLElement).getByText("N/A")).toBeInTheDocument();
     expect(within(footer as HTMLElement).getByText("TBD")).toBeInTheDocument();
   });
+
+  it("does not show an overage row when vaultFoundation.overage is undefined", () => {
+    render(<CostBreakdownTable comparison={fixtureComparison} />);
+    expect(screen.queryByText(/restore overage/i)).not.toBeInTheDocument();
+  });
+
+  it("does not show an overage row when vaultFoundation.overage is 0", () => {
+    render(
+      <CostBreakdownTable
+        comparison={{
+          ...fixtureComparison,
+          vaultFoundation: { ...fixtureComparison.vaultFoundation, overage: 0 },
+        }}
+      />,
+    );
+    expect(screen.queryByText(/restore overage/i)).not.toBeInTheDocument();
+  });
+
+  it("shows 'Restore Overage (> 20%)' row when vaultFoundation.overage > 0", () => {
+    render(
+      <CostBreakdownTable
+        comparison={{
+          ...fixtureComparison,
+          vaultFoundation: {
+            ...fixtureComparison.vaultFoundation,
+            overage: 317.5,
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Restore Overage (> 20%)")).toBeInTheDocument();
+    expect(screen.getByText("$317.50")).toBeInTheDocument();
+  });
+
+  it("overage row shows '--' for Advanced and DIY columns", () => {
+    render(
+      <CostBreakdownTable
+        comparison={{
+          ...fixtureComparison,
+          vaultFoundation: {
+            ...fixtureComparison.vaultFoundation,
+            overage: 317.5,
+          },
+        }}
+      />,
+    );
+    // With overage row: 4 existing dash rows + 3 new dashes in overage row (Advanced + 2 DIY)
+    // Original 8 dashes + 3 = 11 total
+    expect(screen.getAllByText("--").length).toBeGreaterThan(8);
+  });
 });

--- a/src/__tests__/diy-calculator.test.ts
+++ b/src/__tests__/diy-calculator.test.ts
@@ -6,7 +6,9 @@ import {
   calculateRetrievalCost,
   calculateEgressCost,
   calculateDiyCost,
+  calculateVaultFoundationOverage,
 } from "@/lib/diy-calculator";
+import { ANNUAL_READ_FACTOR, ANNUAL_EGRESS_FACTOR } from "@/lib/constants";
 import type { CloudStoragePricing } from "@/types/pricing";
 
 describe("calculateStorageCost", () => {
@@ -166,5 +168,264 @@ describe("calculateDiyCost with excludeEgress option", () => {
     const explicit = calculateDiyCost(10, 3, pricing, {});
     const implicit = calculateDiyCost(10, 3, pricing);
     expect(explicit.total).toBeCloseTo(implicit.total, 10);
+  });
+});
+
+describe("calculateReadOpsCost with custom readFactor", () => {
+  it("behaves identically to default when readFactor equals ANNUAL_READ_FACTOR", () => {
+    const default_ = calculateReadOpsCost(10, 0.0004, 1000, 3);
+    const explicit = calculateReadOpsCost(
+      10,
+      0.0004,
+      1000,
+      3,
+      ANNUAL_READ_FACTOR,
+    );
+    expect(explicit).toBeCloseTo(default_, 10);
+  });
+
+  it("scales result when readFactor is 0.5 (2.5× the default 0.2)", () => {
+    const default_ = calculateReadOpsCost(10, 0.0004, 1000, 3);
+    const custom = calculateReadOpsCost(10, 0.0004, 1000, 3, 0.5);
+    expect(custom).toBeCloseTo(default_ * 2.5, 4);
+  });
+
+  it("returns 0 when readFactor is 0", () => {
+    expect(calculateReadOpsCost(10, 0.0004, 1000, 3, 0)).toBe(0);
+  });
+});
+
+describe("calculateRetrievalCost with custom readFactor", () => {
+  it("behaves identically to default when readFactor equals ANNUAL_READ_FACTOR", () => {
+    const default_ = calculateRetrievalCost(10, 0.01, 3);
+    const explicit = calculateRetrievalCost(10, 0.01, 3, ANNUAL_READ_FACTOR);
+    expect(explicit).toBeCloseTo(default_, 10);
+  });
+
+  it("scales result when readFactor is 0.5", () => {
+    const default_ = calculateRetrievalCost(10, 0.01, 3);
+    const custom = calculateRetrievalCost(10, 0.01, 3, 0.5);
+    expect(custom).toBeCloseTo(default_ * 2.5, 4);
+  });
+
+  it("returns 0 when readFactor is 0", () => {
+    expect(calculateRetrievalCost(10, 0.01, 3, 0)).toBe(0);
+  });
+});
+
+describe("calculateEgressCost with custom egressFactor", () => {
+  it("behaves identically to default when egressFactor equals ANNUAL_EGRESS_FACTOR", () => {
+    const default_ = calculateEgressCost(10, 0.09, 3);
+    const explicit = calculateEgressCost(10, 0.09, 3, ANNUAL_EGRESS_FACTOR);
+    expect(explicit).toBeCloseTo(default_, 10);
+  });
+
+  it("scales result when egressFactor is 0.5", () => {
+    const default_ = calculateEgressCost(10, 0.09, 3);
+    const custom = calculateEgressCost(10, 0.09, 3, 0.5);
+    expect(custom).toBeCloseTo(default_ * 2.5, 4);
+  });
+
+  it("returns 0 when egressFactor is 0", () => {
+    expect(calculateEgressCost(10, 0, 3, 0)).toBe(0);
+  });
+});
+
+describe("calculateDiyCost with restorePercentage option", () => {
+  const pricing: CloudStoragePricing = {
+    storagePerGbMonth: 0.023,
+    writeOpsCost: 0.005,
+    readOpsCost: 0.0004,
+    opsBatchSize: 1000,
+    retrievalPerGb: 0.01,
+    egressPerGb: 0.09,
+  };
+
+  it("readOps scales with restorePercentage", () => {
+    const at20 = calculateDiyCost(10, 3, pricing, { restorePercentage: 20 });
+    const at40 = calculateDiyCost(10, 3, pricing, { restorePercentage: 40 });
+    expect(at40.readOps).toBeCloseTo(at20.readOps * 2, 4);
+  });
+
+  it("dataRetrieval scales with restorePercentage", () => {
+    const at20 = calculateDiyCost(10, 3, pricing, { restorePercentage: 20 });
+    const at40 = calculateDiyCost(10, 3, pricing, { restorePercentage: 40 });
+    expect(at40.dataRetrieval).toBeCloseTo(at20.dataRetrieval * 2, 4);
+  });
+
+  it("internetEgress scales with restorePercentage", () => {
+    const at20 = calculateDiyCost(10, 3, pricing, { restorePercentage: 20 });
+    const at40 = calculateDiyCost(10, 3, pricing, { restorePercentage: 40 });
+    expect(at40.internetEgress).toBeCloseTo(at20.internetEgress * 2, 4);
+  });
+
+  it("storage and writeOps are unaffected by restorePercentage", () => {
+    const at20 = calculateDiyCost(10, 3, pricing, { restorePercentage: 20 });
+    const at40 = calculateDiyCost(10, 3, pricing, { restorePercentage: 40 });
+    expect(at40.storage).toBeCloseTo(at20.storage, 10);
+    expect(at40.writeOps).toBeCloseTo(at20.writeOps, 10);
+  });
+
+  it("behaves identically to default (20%) when restorePercentage is omitted", () => {
+    const omitted = calculateDiyCost(10, 3, pricing);
+    const explicit = calculateDiyCost(10, 3, pricing, {
+      restorePercentage: 20,
+    });
+    expect(omitted.total).toBeCloseTo(explicit.total, 10);
+  });
+
+  it("all costs are zero when restorePercentage is 0 except storage and writeOps", () => {
+    const result = calculateDiyCost(10, 3, pricing, { restorePercentage: 0 });
+    expect(result.readOps).toBe(0);
+    expect(result.dataRetrieval).toBe(0);
+    expect(result.internetEgress).toBe(0);
+    expect(result.storage).toBeGreaterThan(0);
+    expect(result.writeOps).toBeGreaterThan(0);
+  });
+});
+
+describe("calculateVaultFoundationOverage", () => {
+  const iaLikePricing: CloudStoragePricing = {
+    storagePerGbMonth: 0.0125,
+    writeOpsCost: 0.01,
+    readOpsCost: 0.001,
+    opsBatchSize: 1000,
+    retrievalPerGb: 0.01,
+    egressPerGb: 0.085,
+  };
+
+  it("returns 0 when restorePercentage is exactly 20", () => {
+    expect(
+      calculateVaultFoundationOverage(10, 3, 20, iaLikePricing, false),
+    ).toBe(0);
+  });
+
+  it("returns 0 when restorePercentage is below 20", () => {
+    expect(
+      calculateVaultFoundationOverage(10, 3, 10, iaLikePricing, false),
+    ).toBe(0);
+  });
+
+  it("returns 0 when restorePercentage is 0", () => {
+    expect(
+      calculateVaultFoundationOverage(10, 3, 0, iaLikePricing, false),
+    ).toBe(0);
+  });
+
+  it("charges only the incremental fraction above 20%", () => {
+    // restore=40% → incremental factor = 0.20 (same as the base 20%)
+    // so overage should equal a full base-20% cost (readOps + retrieval + egress)
+    const overage = calculateVaultFoundationOverage(
+      10,
+      3,
+      40,
+      iaLikePricing,
+      false,
+    );
+    const baseReadOps = calculateReadOpsCost(
+      10,
+      iaLikePricing.readOpsCost,
+      iaLikePricing.opsBatchSize,
+      3,
+      0.2,
+    );
+    const baseRetrieval = calculateRetrievalCost(
+      10,
+      iaLikePricing.retrievalPerGb,
+      3,
+      0.2,
+    );
+    const baseEgress = calculateEgressCost(
+      10,
+      iaLikePricing.egressPerGb,
+      3,
+      0.2,
+    );
+    expect(overage).toBeCloseTo(baseReadOps + baseRetrieval + baseEgress, 4);
+  });
+
+  it("suppresses egress when excludeEgress is true", () => {
+    const withEgress = calculateVaultFoundationOverage(
+      10,
+      3,
+      50,
+      iaLikePricing,
+      false,
+    );
+    const withoutEgress = calculateVaultFoundationOverage(
+      10,
+      3,
+      50,
+      iaLikePricing,
+      true,
+    );
+    expect(withoutEgress).toBeLessThan(withEgress);
+    // The difference should equal the egress portion
+    const egressPortion = calculateEgressCost(
+      10,
+      iaLikePricing.egressPerGb,
+      3,
+      0.3,
+    );
+    expect(withEgress - withoutEgress).toBeCloseTo(egressPortion, 4);
+  });
+
+  it("scales linearly with termYears", () => {
+    const threeYear = calculateVaultFoundationOverage(
+      10,
+      3,
+      50,
+      iaLikePricing,
+      false,
+    );
+    const oneYear = calculateVaultFoundationOverage(
+      10,
+      1,
+      50,
+      iaLikePricing,
+      false,
+    );
+    expect(threeYear).toBeCloseTo(oneYear * 3, 4);
+  });
+
+  it("scales linearly with capacityTiB", () => {
+    const ten = calculateVaultFoundationOverage(
+      10,
+      3,
+      50,
+      iaLikePricing,
+      false,
+    );
+    const twenty = calculateVaultFoundationOverage(
+      20,
+      3,
+      50,
+      iaLikePricing,
+      false,
+    );
+    expect(twenty).toBeCloseTo(ten * 2, 4);
+  });
+
+  it("returns 0 when retrievalPerGb is 0 and excludeEgress is true (read ops only)", () => {
+    const standardPricing: CloudStoragePricing = {
+      ...iaLikePricing,
+      retrievalPerGb: 0,
+    };
+    const overage = calculateVaultFoundationOverage(
+      10,
+      3,
+      50,
+      standardPricing,
+      true,
+    );
+    // Only read ops contribute
+    const expectedReadOps = calculateReadOpsCost(
+      10,
+      standardPricing.readOpsCost,
+      standardPricing.opsBatchSize,
+      3,
+      0.3,
+    );
+    expect(overage).toBeCloseTo(expectedReadOps, 4);
   });
 });

--- a/src/__tests__/reduced-motion.test.tsx
+++ b/src/__tests__/reduced-motion.test.tsx
@@ -38,6 +38,7 @@ describe("reduced motion", () => {
           comparison={fixtureComparison}
           capacityTiB={FIXTURE_CAPACITY_TIB}
           termYears={FIXTURE_TERM_YEARS}
+          restorePercentage={20}
         />
         <RegionSelector
           regions={[]}

--- a/src/__tests__/restore-percentage-slider.test.tsx
+++ b/src/__tests__/restore-percentage-slider.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RestorePercentageSlider } from "@/components/calculator/restore-percentage-slider";
+
+describe("RestorePercentageSlider", () => {
+  it("renders a slider with role 'slider'", () => {
+    render(
+      <RestorePercentageSlider
+        value={20}
+        capacityTiB={0}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(screen.getByRole("slider")).toBeInTheDocument();
+  });
+
+  it("has aria-label 'Annual restore percentage'", () => {
+    render(
+      <RestorePercentageSlider
+        value={20}
+        capacityTiB={0}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("slider", { name: /annual restore percentage/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows percentage only when capacityTiB is 0", () => {
+    render(
+      <RestorePercentageSlider
+        value={20}
+        capacityTiB={0}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(screen.getByText("20%")).toBeInTheDocument();
+  });
+
+  it("shows TiB equivalent when capacityTiB is set", () => {
+    render(
+      <RestorePercentageSlider
+        value={20}
+        capacityTiB={200}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(screen.getByText("40.0 TiB (20%)")).toBeInTheDocument();
+  });
+
+  it("TiB display has aria-live='polite'", () => {
+    render(
+      <RestorePercentageSlider
+        value={20}
+        capacityTiB={200}
+        onValueChange={() => undefined}
+      />,
+    );
+    const liveRegion = screen.getByText("40.0 TiB (20%)");
+    expect(liveRegion).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("does not show overage note when value is exactly 20", () => {
+    render(
+      <RestorePercentageSlider
+        value={20}
+        capacityTiB={100}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+  });
+
+  it("does not show overage note when value is below 20", () => {
+    render(
+      <RestorePercentageSlider
+        value={10}
+        capacityTiB={100}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+  });
+
+  it("shows overage note (role='note') when value is above 20", () => {
+    render(
+      <RestorePercentageSlider
+        value={50}
+        capacityTiB={100}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(screen.getByRole("note")).toBeInTheDocument();
+  });
+
+  it("overage note mentions infrequent-access rates", () => {
+    render(
+      <RestorePercentageSlider
+        value={50}
+        capacityTiB={100}
+        onValueChange={() => undefined}
+      />,
+    );
+    expect(screen.getByRole("note")).toHaveTextContent(/infrequent-access/i);
+  });
+
+  it("calls onValueChange with the new value on arrow key", () => {
+    const handleChange = vi.fn();
+    render(
+      <RestorePercentageSlider
+        value={20}
+        capacityTiB={100}
+        onValueChange={handleChange}
+      />,
+    );
+    const slider = screen.getByRole("slider");
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(handleChange).toHaveBeenCalledWith(21);
+  });
+});

--- a/src/__tests__/results-panel.test.tsx
+++ b/src/__tests__/results-panel.test.tsx
@@ -36,6 +36,7 @@ describe("ResultsPanel", () => {
         comparison={null}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={FIXTURE_TERM_YEARS}
+        restorePercentage={20}
       />,
     );
 
@@ -48,6 +49,7 @@ describe("ResultsPanel", () => {
         comparison={fixtureComparison}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={FIXTURE_TERM_YEARS}
+        restorePercentage={20}
       />,
     );
 
@@ -72,6 +74,7 @@ describe("ResultsPanel", () => {
         comparison={fixtureComparison}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={FIXTURE_TERM_YEARS}
+        restorePercentage={20}
       />,
     );
 
@@ -86,6 +89,7 @@ describe("ResultsPanel", () => {
         comparison={fixtureComparison}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={3}
+        restorePercentage={20}
       />,
     );
 
@@ -98,6 +102,7 @@ describe("ResultsPanel", () => {
         comparison={fixtureComparison}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={1}
+        restorePercentage={20}
       />,
     );
 
@@ -112,6 +117,7 @@ describe("ResultsPanel", () => {
         comparison={fixtureComparison}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={3}
+        restorePercentage={20}
       />,
     );
 
@@ -128,6 +134,7 @@ describe("ResultsPanel", () => {
         comparison={fixtureComparison}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={3}
+        restorePercentage={20}
       />,
     );
 
@@ -141,6 +148,7 @@ describe("ResultsPanel", () => {
         comparison={fixtureComparison}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={1}
+        restorePercentage={20}
       />,
     );
 
@@ -164,11 +172,33 @@ describe("ResultsPanel", () => {
         }}
         capacityTiB={FIXTURE_CAPACITY_TIB}
         termYears={FIXTURE_TERM_YEARS}
+        restorePercentage={20}
       />,
     );
 
     expect(
       screen.getByText(/non-core pricing has not yet been announced/i),
     ).toBeInTheDocument();
+  });
+
+  it("threads restorePercentage to Assumptions", () => {
+    render(
+      <ResultsPanel
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+        restorePercentage={50}
+      />,
+    );
+
+    const breakdownTab = screen.getByRole("tab", { name: "Breakdown" });
+    fireEvent.mouseDown(breakdownTab);
+    fireEvent.click(breakdownTab);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /calculation assumptions/i }),
+    );
+
+    expect(screen.getByText(/50% annual restore/i)).toBeInTheDocument();
   });
 });

--- a/src/__tests__/slider.test.tsx
+++ b/src/__tests__/slider.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Slider } from "@/components/ui/slider";
+
+describe("Slider primitive", () => {
+  it("renders without crashing", () => {
+    render(<Slider value={[20]} onValueChange={() => undefined} />);
+  });
+
+  it("has a slider role", () => {
+    render(<Slider value={[20]} onValueChange={() => undefined} />);
+    expect(screen.getByRole("slider")).toBeInTheDocument();
+  });
+
+  it("has data-slot='slider' on the root", () => {
+    const { container } = render(
+      <Slider value={[20]} onValueChange={() => undefined} />,
+    );
+    expect(container.querySelector("[data-slot='slider']")).toBeInTheDocument();
+  });
+
+  it("has data-slot='slider-thumb' on the thumb", () => {
+    const { container } = render(
+      <Slider value={[20]} onValueChange={() => undefined} />,
+    );
+    expect(
+      container.querySelector("[data-slot='slider-thumb']"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/summary-cards.test.tsx
+++ b/src/__tests__/summary-cards.test.tsx
@@ -78,6 +78,55 @@ describe("SummaryCards", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses derived effective rate for Foundation when overage is present", () => {
+    // total = 5040 + 1260 overage = 6300
+    // derived rate = 6300 / (10 TiB * 3 years * 12 months) = $17.50/TB/mo
+    render(
+      <SummaryCards
+        comparison={{
+          ...fixtureComparison,
+          vaultFoundation: {
+            ...fixtureComparison.vaultFoundation,
+            total: 6300,
+            overage: 1260,
+          },
+        }}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    const foundationCard = screen
+      .getByText("VDC Vault Foundation")
+      .closest('[data-slot="card"]');
+
+    // Should show derived rate, not the fixed $14/TB/mo
+    expect(
+      within(foundationCard as HTMLElement).getByText("$17.5/TB/mo"),
+    ).toBeInTheDocument();
+    expect(
+      within(foundationCard as HTMLElement).queryByText("$14/TB/mo"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses perTbMonth for Foundation rate when no overage", () => {
+    render(
+      <SummaryCards
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    const foundationCard = screen
+      .getByText("VDC Vault Foundation")
+      .closest('[data-slot="card"]');
+
+    expect(
+      within(foundationCard as HTMLElement).getByText("$14/TB/mo"),
+    ).toBeInTheDocument();
+  });
+
   it("shows ZRS not available text and excludes it from cheapest when option1 unavailable", () => {
     render(
       <SummaryCards

--- a/src/__tests__/url-params.test.ts
+++ b/src/__tests__/url-params.test.ts
@@ -115,6 +115,7 @@ describe("serialiseUrlParams", () => {
       regionId: "aws-us-east-1",
       termYears: 3,
       capacityTiB: 50,
+      restorePercentage: 20,
     };
     expect(serialiseUrlParams(inputs)).toBe(
       "region=aws-us-east-1&term=3&capacity=50",
@@ -126,20 +127,25 @@ describe("serialiseUrlParams", () => {
       regionId: "azure-eastus2",
       termYears: 1,
       capacityTiB: 1,
+      restorePercentage: 20,
     };
     expect(serialiseUrlParams(inputs)).toBe(
       "region=azure-eastus2&term=1&capacity=1",
     );
   });
 
-  it("round-trips through parseUrlParams", () => {
+  it("round-trips non-default restorePercentage through parseUrlParams", () => {
     const inputs: CalculatorInputs = {
       regionId: "aws-eu-west-1",
       termYears: 5,
       capacityTiB: 250,
+      restorePercentage: 50,
     };
     const result = parseUrlParams("?" + serialiseUrlParams(inputs));
-    expect(result).toEqual(inputs);
+    expect(result.restorePercentage).toBe(50);
+    expect(result.regionId).toBe("aws-eu-west-1");
+    expect(result.termYears).toBe(5);
+    expect(result.capacityTiB).toBe(250);
   });
 
   it("includes egress=0 when excludeEgress is true", () => {
@@ -148,6 +154,7 @@ describe("serialiseUrlParams", () => {
       termYears: 3,
       capacityTiB: 50,
       excludeEgress: true,
+      restorePercentage: 20,
     };
     expect(serialiseUrlParams(inputs)).toContain("egress=0");
   });
@@ -158,6 +165,7 @@ describe("serialiseUrlParams", () => {
       termYears: 3,
       capacityTiB: 50,
       excludeEgress: false,
+      restorePercentage: 20,
     };
     expect(serialiseUrlParams(inputs)).not.toContain("egress");
   });
@@ -167,6 +175,7 @@ describe("serialiseUrlParams", () => {
       regionId: "aws-us-east-1",
       termYears: 3,
       capacityTiB: 50,
+      restorePercentage: 20,
     };
     expect(serialiseUrlParams(inputs)).not.toContain("egress");
   });
@@ -177,8 +186,87 @@ describe("serialiseUrlParams", () => {
       termYears: 5,
       capacityTiB: 250,
       excludeEgress: true,
+      restorePercentage: 20,
     };
     const result = parseUrlParams("?" + serialiseUrlParams(inputs));
     expect(result.excludeEgress).toBe(true);
+  });
+
+  it("omits restore param when restorePercentage is 20 (default)", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 50,
+      restorePercentage: 20,
+    };
+    expect(serialiseUrlParams(inputs)).not.toContain("restore");
+  });
+
+  it("includes restore=50 when restorePercentage is 50", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 50,
+      restorePercentage: 50,
+    };
+    expect(serialiseUrlParams(inputs)).toContain("restore=50");
+  });
+
+  it("includes restore=0 when restorePercentage is 0", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 50,
+      restorePercentage: 0,
+    };
+    expect(serialiseUrlParams(inputs)).toContain("restore=0");
+  });
+});
+
+describe("parseUrlParams restore param", () => {
+  it("parses restore=50 as restorePercentage: 50", () => {
+    const result = parseUrlParams("?restore=50");
+    expect(result.restorePercentage).toBe(50);
+  });
+
+  it("parses restore=0 as restorePercentage: 0", () => {
+    const result = parseUrlParams("?restore=0");
+    expect(result.restorePercentage).toBe(0);
+  });
+
+  it("parses restore=100 as restorePercentage: 100", () => {
+    const result = parseUrlParams("?restore=100");
+    expect(result.restorePercentage).toBe(100);
+  });
+
+  it("omits restorePercentage when restore param is absent", () => {
+    const result = parseUrlParams("?region=aws-us-east-1");
+    expect(result).not.toHaveProperty("restorePercentage");
+  });
+
+  it("ignores restore=101 (above maximum)", () => {
+    const result = parseUrlParams("?restore=101");
+    expect(result).not.toHaveProperty("restorePercentage");
+  });
+
+  it("ignores restore=-1 (below minimum)", () => {
+    const result = parseUrlParams("?restore=-1");
+    expect(result).not.toHaveProperty("restorePercentage");
+  });
+
+  it("ignores restore=abc (non-numeric)", () => {
+    const result = parseUrlParams("?restore=abc");
+    expect(result).not.toHaveProperty("restorePercentage");
+  });
+
+  it("round-trips restorePercentage=75 through serialiseUrlParams", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 3,
+      capacityTiB: 50,
+      restorePercentage: 75,
+    };
+    const result = parseUrlParams("?" + serialiseUrlParams(inputs));
+    expect(result.restorePercentage).toBe(75);
   });
 });

--- a/src/__tests__/use-url-state.test.tsx
+++ b/src/__tests__/use-url-state.test.tsx
@@ -8,6 +8,7 @@ const INPUTS: CalculatorInputs = {
   regionId: "aws-us-east-1",
   termYears: 3,
   capacityTiB: 50,
+  restorePercentage: 20,
 };
 
 function setLocationSearch(search: string) {

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { CapacityInput } from "@/components/calculator/capacity-input";
 import { EgressToggle } from "@/components/calculator/egress-toggle";
 import { RegionSelector } from "@/components/calculator/region-selector";
+import { RestorePercentageSlider } from "@/components/calculator/restore-percentage-slider";
 import { TermSelector } from "@/components/calculator/term-selector";
 import {
   Card,
@@ -39,6 +40,9 @@ export function CalculatorForm({
   const [excludeEgress, setExcludeEgress] = useState(
     initialValues?.excludeEgress ?? false,
   );
+  const [restorePercentage, setRestorePercentage] = useState(
+    initialValues?.restorePercentage ?? 20,
+  );
 
   // Before the user makes an explicit choice, derive the region from initialValues.
   // After user interaction, userHasSelected takes precedence.
@@ -70,8 +74,15 @@ export function CalculatorForm({
       termYears,
       capacityTiB,
       excludeEgress,
+      restorePercentage,
     };
-  }, [capacityTiB, excludeEgress, selectedRegion, termYears]);
+  }, [
+    capacityTiB,
+    excludeEgress,
+    restorePercentage,
+    selectedRegion,
+    termYears,
+  ]);
 
   useEffect(() => {
     onInputsChange(completeInputs);
@@ -107,6 +118,13 @@ export function CalculatorForm({
             value={capacityTiB}
             onCapacityChange={setCapacityTiB}
           />
+          <div className="lg:col-span-2">
+            <RestorePercentageSlider
+              value={restorePercentage}
+              capacityTiB={capacityTiB}
+              onValueChange={setRestorePercentage}
+            />
+          </div>
           <div className="lg:col-span-2">
             <EgressToggle
               checked={excludeEgress}

--- a/src/components/calculator/restore-percentage-slider.tsx
+++ b/src/components/calculator/restore-percentage-slider.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 
@@ -12,10 +14,18 @@ export function RestorePercentageSlider({
   capacityTiB,
   onValueChange,
 }: RestorePercentageSliderProps) {
+  // draft tracks the live thumb position for display; the parent is only notified on commit
+  const [draft, setDraft] = useState(value);
+
+  // Sync draft if parent value changes externally (e.g., URL-derived initial value)
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
   const tibDisplay =
     capacityTiB > 0
-      ? `${((value / 100) * capacityTiB).toFixed(1)} TiB (${value}%)`
-      : `${value}%`;
+      ? `${((draft / 100) * capacityTiB).toFixed(1)} TiB (${draft}%)`
+      : `${draft}%`;
 
   return (
     <div className="border-border/70 grid gap-3 rounded-2xl border bg-[color:var(--card-tint-neutral)]/70 p-4">
@@ -36,12 +46,13 @@ export function RestorePercentageSlider({
         min={0}
         max={100}
         step={1}
-        value={[value]}
-        onValueChange={([next]) => onValueChange(next)}
+        value={[draft]}
+        onValueChange={([next]) => setDraft(next)}
+        onValueCommit={([committed]) => onValueChange(committed)}
         aria-label="Annual restore percentage"
-        aria-describedby={value > 20 ? "restore-overage-note" : undefined}
+        aria-describedby={draft > 20 ? "restore-overage-note" : undefined}
       />
-      {value > 20 && (
+      {draft > 20 && (
         <p
           id="restore-overage-note"
           className="text-muted-foreground text-sm leading-snug"

--- a/src/components/calculator/restore-percentage-slider.tsx
+++ b/src/components/calculator/restore-percentage-slider.tsx
@@ -1,0 +1,56 @@
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+
+interface RestorePercentageSliderProps {
+  value: number;
+  capacityTiB: number;
+  onValueChange: (value: number) => void;
+}
+
+export function RestorePercentageSlider({
+  value,
+  capacityTiB,
+  onValueChange,
+}: RestorePercentageSliderProps) {
+  const tibDisplay =
+    capacityTiB > 0
+      ? `${((value / 100) * capacityTiB).toFixed(1)} TiB (${value}%)`
+      : `${value}%`;
+
+  return (
+    <div className="border-border/70 grid gap-3 rounded-2xl border bg-[color:var(--card-tint-neutral)]/70 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <Label htmlFor="restore-percentage" className="leading-none">
+          Annual restore
+        </Label>
+        <span
+          aria-live="polite"
+          aria-atomic="true"
+          className="text-muted-foreground text-sm font-medium [font-variant-numeric:tabular-nums]"
+        >
+          {tibDisplay}
+        </span>
+      </div>
+      <Slider
+        id="restore-percentage"
+        min={0}
+        max={100}
+        step={1}
+        value={[value]}
+        onValueChange={([next]) => onValueChange(next)}
+        aria-label="Annual restore percentage"
+        aria-describedby={value > 20 ? "restore-overage-note" : undefined}
+      />
+      {value > 20 && (
+        <p
+          id="restore-overage-note"
+          className="text-muted-foreground text-sm leading-snug"
+          role="note"
+        >
+          Restore above 20% incurs Vault Foundation overage charges (read ops,
+          data retrieval, and internet egress) at infrequent-access rates.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/results/assumptions.tsx
+++ b/src/components/results/assumptions.tsx
@@ -6,7 +6,11 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 
-export function Assumptions() {
+interface AssumptionsProps {
+  restorePercentage: number;
+}
+
+export function Assumptions({ restorePercentage }: AssumptionsProps) {
   return (
     <Collapsible className="border-border/70 bg-background/90 rounded-[1.5rem] border shadow-[0_24px_72px_-48px_color-mix(in_oklab,var(--electric-azure)_55%,transparent)]">
       <CollapsibleTrigger className="group flex w-full items-center justify-between gap-4 px-6 py-5 text-left">
@@ -27,12 +31,9 @@ export function Assumptions() {
             1 MB operation size is applied to every write and read transaction.
           </li>
           <li>
-            20% annual read-back is assumed for data restored from archive
-            storage.
-          </li>
-          <li>
-            20% annual egress is assumed for internet transfer out of the
-            platform.
+            {restorePercentage}% annual restore is assumed for data read back
+            and egressed from the platform (configurable via the restore
+            slider).
           </li>
           <li>
             AWS storage rates use the published 50 TB–500 TB price tier and

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -38,6 +38,16 @@ function formatVaultTotal(result: VaultCostResult): string {
   return formatUSD(result.total);
 }
 
+function formatVaultStorageCost(result: VaultCostResult): string {
+  if (result.pricingTbd) return "TBD";
+  if (result.total === null) return "N/A";
+  const base =
+    result.overage !== undefined && result.overage > 0
+      ? result.total - result.overage
+      : result.total;
+  return formatUSD(base);
+}
+
 export function CostBreakdownTable({
   comparison,
   excludeEgress,
@@ -49,7 +59,7 @@ export function CostBreakdownTable({
     const rows: BreakdownRow[] = [
       {
         category: "Storage",
-        foundation: formatVaultTotal(comparison.vaultFoundation),
+        foundation: formatVaultStorageCost(comparison.vaultFoundation),
         advanced: formatVaultTotal(comparison.vaultAdvanced),
         diyOption1: fmt1(comparison.diyOption1.storage),
         diyOption2: formatUSD(comparison.diyOption2.storage),

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -46,7 +46,7 @@ export function CostBreakdownTable({
     const fmt1 = (val: number) =>
       comparison.diyOption1Unavailable ? "N/A" : formatUSD(val);
 
-    return [
+    const rows: BreakdownRow[] = [
       {
         category: "Storage",
         foundation: formatVaultTotal(comparison.vaultFoundation),
@@ -85,6 +85,19 @@ export function CostBreakdownTable({
         diyOption2: formatUSD(comparison.diyOption2.internetEgress),
       },
     ];
+
+    const overage = comparison.vaultFoundation.overage;
+    if (overage !== undefined && overage > 0) {
+      rows.splice(4, 0, {
+        category: "Restore Overage (> 20%)",
+        foundation: formatUSD(overage),
+        advanced: "--",
+        diyOption1: "--",
+        diyOption2: "--",
+      });
+    }
+
+    return rows;
   }, [comparison, excludeEgress]);
 
   return (

--- a/src/components/results/results-panel.tsx
+++ b/src/components/results/results-panel.tsx
@@ -15,6 +15,7 @@ interface ResultsPanelProps {
   capacityTiB: number;
   termYears: number;
   excludeEgress?: boolean;
+  restorePercentage: number;
 }
 
 export function ResultsPanel({
@@ -22,6 +23,7 @@ export function ResultsPanel({
   capacityTiB,
   termYears,
   excludeEgress,
+  restorePercentage,
 }: ResultsPanelProps) {
   const [activeTab, setActiveTab] = useState("overview");
   const showTrend = termYears > 1;
@@ -88,7 +90,7 @@ export function ResultsPanel({
             comparison={comparison}
             excludeEgress={excludeEgress}
           />
-          <Assumptions />
+          <Assumptions restorePercentage={restorePercentage} />
         </TabsContent>
 
         {showTrend && (

--- a/src/components/results/summary-cards.tsx
+++ b/src/components/results/summary-cards.tsx
@@ -77,12 +77,21 @@ export function SummaryCards({
   capacityTiB,
   termYears,
 }: SummaryCardsProps) {
+  const foundationTotal = comparison.vaultFoundation.total;
+  const foundationOverage = comparison.vaultFoundation.overage;
+  const foundationRate =
+    foundationOverage !== undefined &&
+    foundationOverage > 0 &&
+    foundationTotal !== null
+      ? deriveDiyRate(foundationTotal, capacityTiB, termYears)
+      : comparison.vaultFoundation.perTbMonth;
+
   const cards: SummaryCardItem[] = [
     {
       id: "vault-foundation",
       title: "VDC Vault Foundation",
-      total: comparison.vaultFoundation.total,
-      rate: comparison.vaultFoundation.perTbMonth,
+      total: foundationTotal,
+      rate: foundationRate,
       pricingTbd: comparison.vaultFoundation.pricingTbd,
     },
     {

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+import { Slider as SliderPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Slider({
+  className,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      className={cn(
+        "relative flex w-full touch-none items-center select-none",
+        "data-[disabled]:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="bg-input relative h-1.5 w-full grow overflow-hidden rounded-full"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="absolute h-full bg-[color:var(--viridis)]"
+        />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        data-slot="slider-thumb"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        className={cn(
+          "bg-background block size-4 rounded-full border-2 border-[color:var(--viridis)] shadow",
+          "focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
+          "disabled:pointer-events-none disabled:opacity-50",
+        )}
+      />
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/src/lib/comparison-engine.ts
+++ b/src/lib/comparison-engine.ts
@@ -1,5 +1,8 @@
 import { calculateVaultCost } from "@/lib/vault-calculator";
-import { calculateDiyCost } from "@/lib/diy-calculator";
+import {
+  calculateDiyCost,
+  calculateVaultFoundationOverage,
+} from "@/lib/diy-calculator";
 import type {
   CalculatorInputs,
   ComparisonResult,
@@ -36,8 +39,11 @@ export function buildComparison(
   region: Region,
   cloudPricing: RegionCloudPricing,
 ): ComparisonResult {
-  const { capacityTiB, termYears, excludeEgress } = inputs;
-  const egressOptions = { excludeEgress: excludeEgress === true };
+  const { capacityTiB, termYears, excludeEgress, restorePercentage } = inputs;
+  const egressOptions = {
+    excludeEgress: excludeEgress === true,
+    restorePercentage,
+  };
 
   const foundationService = region.services.vdc_vault.find(
     (s) => s.edition === "Foundation",
@@ -46,7 +52,7 @@ export function buildComparison(
     (s) => s.edition === "Advanced",
   );
 
-  const vaultFoundation = foundationService
+  const vaultFoundationBase = foundationService
     ? calculateVaultCost(
         capacityTiB,
         termYears,
@@ -55,6 +61,29 @@ export function buildComparison(
         region.provider,
       )
     : UNAVAILABLE;
+
+  const foundationOverage =
+    foundationService && vaultFoundationBase.total !== null
+      ? calculateVaultFoundationOverage(
+          capacityTiB,
+          termYears,
+          restorePercentage,
+          cloudPricing.option2,
+          excludeEgress === true,
+        )
+      : undefined;
+
+  const vaultFoundation: VaultCostResult = {
+    ...vaultFoundationBase,
+    total:
+      vaultFoundationBase.total !== null && foundationOverage !== undefined
+        ? vaultFoundationBase.total + foundationOverage
+        : vaultFoundationBase.total,
+    overage:
+      foundationOverage !== undefined && foundationOverage > 0
+        ? foundationOverage
+        : undefined,
+  };
 
   const vaultAdvanced = advancedService
     ? calculateVaultCost(

--- a/src/lib/diy-calculator.ts
+++ b/src/lib/diy-calculator.ts
@@ -35,45 +35,49 @@ export function calculateWriteOpsCost(
 
 /**
  * Read ops cost.
- * Assumes ANNUAL_READ_FACTOR of stored data is read back per year.
+ * Assumes readFactor of stored data is read back per year (defaults to ANNUAL_READ_FACTOR).
  */
 export function calculateReadOpsCost(
   capacityTiB: number,
   opsCost: number,
   opsBatchSize: number,
   termYears: number,
+  readFactor: number = ANNUAL_READ_FACTOR,
 ): number {
-  const opsPerYear =
-    (capacityTiB * TIB_TO_MB * ANNUAL_READ_FACTOR) / OPERATION_SIZE_MB;
+  const opsPerYear = (capacityTiB * TIB_TO_MB * readFactor) / OPERATION_SIZE_MB;
   return opsPerYear * (opsCost / opsBatchSize) * termYears;
 }
 
 /**
  * Data retrieval cost.
- * Assumes ANNUAL_READ_FACTOR of stored data is retrieved per year.
+ * Assumes readFactor of stored data is retrieved per year (defaults to ANNUAL_READ_FACTOR).
  */
 export function calculateRetrievalCost(
   capacityTiB: number,
   ratePerGb: number,
   termYears: number,
+  readFactor: number = ANNUAL_READ_FACTOR,
 ): number {
-  return capacityTiB * TIB_TO_GB * ANNUAL_READ_FACTOR * ratePerGb * termYears;
+  return capacityTiB * TIB_TO_GB * readFactor * ratePerGb * termYears;
 }
 
 /**
  * Internet egress cost.
- * Assumes ANNUAL_EGRESS_FACTOR of stored data is egressed per year.
+ * Assumes egressFactor of stored data is egressed per year (defaults to ANNUAL_EGRESS_FACTOR).
  */
 export function calculateEgressCost(
   capacityTiB: number,
   ratePerGb: number,
   termYears: number,
+  egressFactor: number = ANNUAL_EGRESS_FACTOR,
 ): number {
-  return capacityTiB * TIB_TO_GB * ANNUAL_EGRESS_FACTOR * ratePerGb * termYears;
+  return capacityTiB * TIB_TO_GB * egressFactor * ratePerGb * termYears;
 }
 
 interface DiyCostOptions {
   excludeEgress?: boolean;
+  /** Annual restore percentage (0–100). Defaults to 20. Drives read ops, retrieval, and egress. */
+  restorePercentage?: number;
 }
 
 /** Compute all DIY cost components and their total. */
@@ -83,7 +87,8 @@ export function calculateDiyCost(
   pricing: CloudStoragePricing,
   options: DiyCostOptions = {},
 ): CostBreakdown {
-  const { excludeEgress = false } = options;
+  const { excludeEgress = false, restorePercentage = 20 } = options;
+  const restoreFactor = restorePercentage / 100;
   const termMonths = termYears * MONTHS_PER_YEAR;
 
   const storage = calculateStorageCost(
@@ -102,17 +107,75 @@ export function calculateDiyCost(
     pricing.readOpsCost,
     pricing.opsBatchSize,
     termYears,
+    restoreFactor,
   );
   const dataRetrieval = calculateRetrievalCost(
     capacityTiB,
     pricing.retrievalPerGb,
     termYears,
+    restoreFactor,
   );
   const internetEgress = excludeEgress
     ? 0
-    : calculateEgressCost(capacityTiB, pricing.egressPerGb, termYears);
+    : calculateEgressCost(
+        capacityTiB,
+        pricing.egressPerGb,
+        termYears,
+        restoreFactor,
+      );
 
   const total = storage + writeOps + readOps + dataRetrieval + internetEgress;
 
   return { storage, writeOps, readOps, dataRetrieval, internetEgress, total };
+}
+
+/**
+ * Calculate the overage cost for Vault Foundation when the restore percentage
+ * exceeds the 20% included in the flat fee.
+ *
+ * Only the incremental fraction above 20% is charged, using option2 cloud
+ * pricing (S3 IA for AWS, Blob LRS for Azure).
+ *
+ * Returns 0 when restorePercentage ≤ 20.
+ */
+export function calculateVaultFoundationOverage(
+  capacityTiB: number,
+  termYears: number,
+  restorePercentage: number,
+  overagePricing: CloudStoragePricing,
+  excludeEgress: boolean,
+): number {
+  const INCLUDED_RESTORE_FRACTION = 0.2;
+  const incrementalFactor = Math.max(
+    0,
+    restorePercentage / 100 - INCLUDED_RESTORE_FRACTION,
+  );
+
+  if (incrementalFactor === 0) {
+    return 0;
+  }
+
+  const readOps = calculateReadOpsCost(
+    capacityTiB,
+    overagePricing.readOpsCost,
+    overagePricing.opsBatchSize,
+    termYears,
+    incrementalFactor,
+  );
+  const dataRetrieval = calculateRetrievalCost(
+    capacityTiB,
+    overagePricing.retrievalPerGb,
+    termYears,
+    incrementalFactor,
+  );
+  const internetEgress = excludeEgress
+    ? 0
+    : calculateEgressCost(
+        capacityTiB,
+        overagePricing.egressPerGb,
+        termYears,
+        incrementalFactor,
+      );
+
+  return readOps + dataRetrieval + internetEgress;
 }

--- a/src/lib/url-params.ts
+++ b/src/lib/url-params.ts
@@ -3,6 +3,9 @@ import type { CalculatorInputs } from "@/types/calculator";
 const TERM_MIN = 1;
 const TERM_MAX = 5;
 const CAPACITY_MIN = 1;
+const RESTORE_MIN = 0;
+const RESTORE_MAX = 100;
+const DEFAULT_RESTORE_PERCENTAGE = 20;
 
 export function parseUrlParams(search: string): Partial<CalculatorInputs> {
   const params = new URLSearchParams(search);
@@ -33,6 +36,14 @@ export function parseUrlParams(search: string): Partial<CalculatorInputs> {
     result.excludeEgress = true;
   }
 
+  const restoreRaw = params.get("restore");
+  if (restoreRaw !== null) {
+    const restore = parseInt(restoreRaw, 10);
+    if (!isNaN(restore) && restore >= RESTORE_MIN && restore <= RESTORE_MAX) {
+      result.restorePercentage = restore;
+    }
+  }
+
   return result;
 }
 
@@ -43,6 +54,9 @@ export function serialiseUrlParams(inputs: CalculatorInputs): string {
   params.set("capacity", String(inputs.capacityTiB));
   if (inputs.excludeEgress === true) {
     params.set("egress", "0");
+  }
+  if (inputs.restorePercentage !== DEFAULT_RESTORE_PERCENTAGE) {
+    params.set("restore", String(inputs.restorePercentage));
   }
   return params.toString();
 }

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -3,6 +3,7 @@ export interface CalculatorInputs {
   termYears: number;
   capacityTiB: number;
   excludeEgress?: boolean;
+  restorePercentage: number;
 }
 
 export interface CostBreakdown {
@@ -21,6 +22,8 @@ export interface VaultCostResult {
   perTbMonth: number | null;
   /** True when tier is Non-Core and pricing is not yet set */
   pricingTbd: boolean;
+  /** Overage cost when restore percentage exceeds the included 20% (Foundation only) */
+  overage?: number;
 }
 
 export interface ComparisonResult {


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 20% annual restore assumption with a configurable 0–100% slider (default 20%)
- Vault Foundation includes 20% restores in its flat fee; sliding above 20% adds overage charges (read ops + data retrieval + egress) at the region's infrequent-access rates, surfaced as a dedicated row in the cost breakdown table
- DIY read ops, data retrieval, and egress calculations all adopt the dynamic restore factor
- URL state: `restore=N` param included when non-default (omitted when N=20 to keep share links clean)
- Slider displays live TiB equivalent (e.g. "40.0 TiB (20%)") with `aria-live` and an overage note when value exceeds 20%

## Test plan

- [x] `npm run test:run` — 287 tests, 33 test files, all passing
- [x] `npm run lint` — zero errors
- [x] `npm run build` — tsc + vite build succeeds
- [ ] Manual: default 20% → no overage row in breakdown table
- [ ] Manual: slide to 50% with capacity set → shows "X TiB (50%)", overage note visible, Foundation total higher
- [ ] Manual: excludeEgress toggle ON with slider > 20% → Foundation overage drops (no egress component)
- [ ] Manual: share URL at non-default % → URL contains `restore=N`; reload restores slider position

🤖 Generated with [Claude Code](https://claude.com/claude-code)