### PR TITLE
fix(app): surface missing cloud pricing instead of silent blank

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { lazy, Suspense, useCallback, useMemo, useState } from "react";
 import { CalculatorForm } from "@/components/calculator/calculator-form";
 import { SiteFooter } from "@/components/layout/site-footer";
 import { SiteHeader } from "@/components/layout/site-header";
+import { MissingCloudPricingAlert } from "@/components/results/missing-cloud-pricing-alert";
 
 const ResultsPanel = lazy(async () => {
   const m = await import("@/components/results/results-panel");
@@ -50,6 +51,11 @@ function App() {
     return buildComparison(inputs, selectedRegion, pricing);
   }, [inputs, selectedRegion]);
 
+  const cloudPricingMissing = useMemo(() => {
+    if (!selectedRegion) return false;
+    return CLOUD_PRICING[selectedRegion.id] === undefined;
+  }, [selectedRegion]);
+
   return (
     <div className="bg-background text-foreground flex min-h-screen flex-col">
       <SiteHeader />
@@ -77,7 +83,9 @@ function App() {
           />
 
           <div aria-live="polite">
-            {comparison !== null && inputs !== null ? (
+            {cloudPricingMissing && selectedRegion ? (
+              <MissingCloudPricingAlert region={selectedRegion} />
+            ) : comparison !== null && inputs !== null ? (
               <Suspense fallback={null}>
                 <ResultsPanel
                   comparison={comparison}

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -162,6 +162,44 @@ describe("App", () => {
     ).toBeInTheDocument();
   }, 10_000);
 
+  it("shows a missing cloud pricing alert when the selected region has no pricing data", async () => {
+    const unknownRegion: Region = {
+      id: "aws-unknown-region-99",
+      name: "Unknown Region",
+      provider: "AWS",
+      coords: [0, 0],
+      aliases: [],
+      services: {
+        vdc_vault: [
+          { edition: "Foundation", tier: "Core" },
+          { edition: "Advanced", tier: "Core" },
+        ],
+      },
+    };
+
+    vi.mocked(useRegions).mockReturnValue({
+      regions: [unknownRegion],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<App />);
+
+    fireEvent.click(screen.getByRole("combobox", { name: /select a region/i }));
+    fireEvent.click(screen.getByRole("option", { name: /unknown region/i }));
+    fireEvent.change(screen.getByLabelText(/required capacity/i), {
+      target: { value: "8" },
+    });
+
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByText(/cloud pricing unavailable for unknown region/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: /comparison results/i }),
+    ).not.toBeInTheDocument();
+  }, 10_000);
+
   it("calls syncToUrl when the form fires onInputsChange", async () => {
     const syncToUrl = vi.fn();
     vi.mocked(useUrlState).mockReturnValue({

--- a/src/__tests__/missing-cloud-pricing-alert.test.tsx
+++ b/src/__tests__/missing-cloud-pricing-alert.test.tsx
@@ -52,9 +52,9 @@ describe("MissingCloudPricingAlert", () => {
     expect(href).toContain(
       "github.com/comnam90/vdc-vault-tco-calculator/issues/new",
     );
-    expect(href).toContain("aws-ap-southeast-99");
-    expect(href).toContain(
-      encodeURIComponent("Asia Pacific (Fictional)").replace(/%20/g, "+"),
-    );
+    // Decode the URL for readable assertions (URLSearchParams uses + for spaces)
+    const decodedHref = decodeURIComponent(href.replace(/\+/g, " "));
+    expect(decodedHref).toContain("aws-ap-southeast-99");
+    expect(decodedHref).toContain("Asia Pacific (Fictional)");
   });
 });

--- a/src/__tests__/missing-cloud-pricing-alert.test.tsx
+++ b/src/__tests__/missing-cloud-pricing-alert.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MissingCloudPricingAlert } from "@/components/results/missing-cloud-pricing-alert";
+import type { Region } from "@/types/region";
+
+const mockRegion: Region = {
+  id: "aws-ap-southeast-99",
+  name: "Asia Pacific (Fictional)",
+  provider: "AWS",
+  coords: [1.35, 103.82],
+  aliases: ["ap-southeast-99"],
+  services: {
+    vdc_vault: [
+      { edition: "Foundation", tier: "Core" },
+      { edition: "Advanced", tier: "Core" },
+    ],
+  },
+};
+
+describe("MissingCloudPricingAlert", () => {
+  it("renders an alert with the region name in the title", () => {
+    render(<MissingCloudPricingAlert region={mockRegion} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /cloud pricing unavailable for asia pacific \(fictional\)/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("explains that the TCO comparison cannot be shown", () => {
+    render(<MissingCloudPricingAlert region={mockRegion} />);
+
+    expect(
+      screen.getByText(/tco comparison can't be shown/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a link that opens a pre-filled GitHub issue", () => {
+    render(<MissingCloudPricingAlert region={mockRegion} />);
+
+    const link = screen.getByRole("link", {
+      name: /report missing region on github/i,
+    });
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+
+    const href = link.getAttribute("href") ?? "";
+    expect(href).toContain(
+      "github.com/comnam90/vdc-vault-tco-calculator/issues/new",
+    );
+    expect(href).toContain("aws-ap-southeast-99");
+    expect(href).toContain(
+      encodeURIComponent("Asia Pacific (Fictional)").replace(/%20/g, "+"),
+    );
+  });
+});

--- a/src/components/results/missing-cloud-pricing-alert.tsx
+++ b/src/components/results/missing-cloud-pricing-alert.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle, ExternalLink } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import type { Region } from "@/types/region";
+
+interface MissingCloudPricingAlertProps {
+  region: Region;
+}
+
+const REPO = "https://github.com/comnam90/vdc-vault-tco-calculator";
+
+export function MissingCloudPricingAlert({
+  region,
+}: MissingCloudPricingAlertProps) {
+  const params = new URLSearchParams({
+    title: `Missing cloud pricing: ${region.name} (${region.id})`,
+    body: [
+      `The region **${region.name}** (\`${region.id}\`, provider: ${region.provider}) is returned by the VDC Vault API but has no matching cloud pricing data in the calculator.`,
+      ``,
+      `Please add pricing data so the TCO comparison can be shown for this region.`,
+    ].join("\n"),
+    labels: "pricing-data",
+  });
+  const issueUrl = `${REPO}/issues/new?${params.toString()}`;
+
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle />
+      <AlertTitle>Cloud pricing unavailable for {region.name}</AlertTitle>
+      <AlertDescription>
+        <p>
+          We don&apos;t have public cloud pricing data for this region yet. The
+          TCO comparison can&apos;t be shown until pricing is added.
+        </p>
+        <Button variant="outline" size="sm" asChild className="mt-3">
+          <a href={issueUrl} target="_blank" rel="noopener noreferrer">
+            <ExternalLink />
+            Report missing region on GitHub
+          </a>
+        </Button>
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Summary

- Detects when a region returned by the VDC Vault API has no matching entry in `CLOUD_PRICING` and surfaces a clear, actionable alert instead of silently hiding the results panel
- New `MissingCloudPricingAlert` component renders a destructive-variant alert with the region name and a pre-filled GitHub issue link so users can easily report the gap
- `cloudPricingMissing` derived value added in `App.tsx` to distinguish "no data yet" from "data unavailable for this region"

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 292 tests pass (3 new tests in `missing-cloud-pricing-alert.test.tsx`, 1 new test in `app.test.tsx`)
- [x] `npm run build` — production build succeeds
- [ ] Manual smoke test: temporarily comment out a region in `src/data/cloud-pricing.ts`, select it in the UI, confirm the alert renders with the region name and a working GitHub issues deep link

🤖 Generated with [Claude Code](https://claude.com/claude-code)