### PR TITLE
feat(layout): split-pane dashboard at lg breakpoint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,42 +60,48 @@ function App() {
     <div className="bg-background text-foreground flex min-h-screen flex-col">
       <SiteHeader />
       <main className="flex-1 px-4 py-8 sm:px-6 lg:px-8">
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-          {isLoading ? (
-            <p role="status" className="text-muted-foreground text-sm">
-              Loading available regions…
-            </p>
-          ) : null}
-
-          {error ? (
-            <Alert variant="destructive">
-              <AlertTitle>Unable to load regions</AlertTitle>
-              <AlertDescription>
-                {error}. Refresh the page and try again.
-              </AlertDescription>
-            </Alert>
-          ) : null}
-
-          <CalculatorForm
-            key={urlKey}
-            initialValues={urlDerivedInputs}
-            onInputsChange={handleInputsChange}
-          />
-
-          <div aria-live="polite">
-            {cloudPricingMissing && selectedRegion ? (
-              <MissingCloudPricingAlert region={selectedRegion} />
-            ) : comparison !== null && inputs !== null ? (
-              <Suspense fallback={null}>
-                <ResultsPanel
-                  comparison={comparison}
-                  capacityTiB={inputs.capacityTiB}
-                  termYears={inputs.termYears}
-                  excludeEgress={inputs.excludeEgress === true}
-                  restorePercentage={inputs.restorePercentage}
-                />
-              </Suspense>
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 lg:flex-row lg:items-start lg:gap-8">
+          {/* Left pane — sticky inputs sidebar */}
+          <div className="flex shrink-0 flex-col gap-4 lg:sticky lg:top-8 lg:w-[28%]">
+            {isLoading ? (
+              <p role="status" className="text-muted-foreground text-sm">
+                Loading available regions…
+              </p>
             ) : null}
+
+            {error ? (
+              <Alert variant="destructive">
+                <AlertTitle>Unable to load regions</AlertTitle>
+                <AlertDescription>
+                  {error}. Refresh the page and try again.
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
+            <CalculatorForm
+              key={urlKey}
+              initialValues={urlDerivedInputs}
+              onInputsChange={handleInputsChange}
+            />
+          </div>
+
+          {/* Right pane — scrollable results */}
+          <div className="min-w-0 flex-1">
+            <div aria-live="polite">
+              {cloudPricingMissing && selectedRegion ? (
+                <MissingCloudPricingAlert region={selectedRegion} />
+              ) : comparison !== null && inputs !== null ? (
+                <Suspense fallback={null}>
+                  <ResultsPanel
+                    comparison={comparison}
+                    capacityTiB={inputs.capacityTiB}
+                    termYears={inputs.termYears}
+                    excludeEgress={inputs.excludeEgress === true}
+                    restorePercentage={inputs.restorePercentage}
+                  />
+                </Suspense>
+              ) : null}
+            </div>
           </div>
         </div>
       </main>

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -200,6 +200,32 @@ describe("App", () => {
     ).not.toBeInTheDocument();
   }, 10_000);
 
+  it("uses a flex-row split-pane layout container at lg breakpoint", () => {
+    vi.mocked(useRegions).mockReturnValue({
+      regions,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<App />);
+
+    const main = screen.getByRole("main");
+    expect(main.firstElementChild?.className).toMatch(/lg:flex-row/);
+  });
+
+  it("places CalculatorForm in a sticky sidebar for the lg split-pane", () => {
+    vi.mocked(useRegions).mockReturnValue({
+      regions,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<App />);
+
+    const form = screen.getByRole("form", { name: /vault pricing inputs/i });
+    expect(form.closest('[class*="lg:sticky"]')).not.toBeNull();
+  });
+
   it("calls syncToUrl when the form fires onInputsChange", async () => {
     const syncToUrl = vi.fn();
     vi.mocked(useUrlState).mockReturnValue({

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -209,8 +209,8 @@ describe("App", () => {
 
     render(<App />);
 
-    const main = screen.getByRole("main");
-    expect(main.firstElementChild?.className).toMatch(/lg:flex-row/);
+    const form = screen.getByRole("form", { name: /vault pricing inputs/i });
+    expect(form.closest('[class*="lg:flex-row"]')).not.toBeNull();
   });
 
   it("places CalculatorForm in a sticky sidebar for the lg split-pane", () => {

--- a/src/__tests__/calculator-form.test.tsx
+++ b/src/__tests__/calculator-form.test.tsx
@@ -163,7 +163,7 @@ describe("CalculatorForm", () => {
     render(<CalculatorForm onInputsChange={vi.fn()} />);
 
     const form = screen.getByRole("form", { name: /vault pricing inputs/i });
-    expect(form.className).not.toMatch(/lg:grid-cols-\[/);
+    expect(form.className).not.toMatch(/lg:grid-cols-/);
   });
 
   describe("EgressToggle integration", () => {

--- a/src/__tests__/summary-cards.test.tsx
+++ b/src/__tests__/summary-cards.test.tsx
@@ -127,6 +127,19 @@ describe("SummaryCards", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the Lowest total badge on its own line, not inline with the card title", () => {
+    render(
+      <SummaryCards
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    const badge = screen.getByText("Lowest total");
+    expect(badge.closest('[class*="justify-between"]')).toBeNull();
+  });
+
   it("uses xl (not lg) breakpoint for 4-column layout to avoid overflow inside the split-pane right pane", () => {
     render(
       <SummaryCards

--- a/src/__tests__/summary-cards.test.tsx
+++ b/src/__tests__/summary-cards.test.tsx
@@ -127,6 +127,19 @@ describe("SummaryCards", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders Lowest total badge outside the card header so title rows align across all cards", () => {
+    render(
+      <SummaryCards
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    const badge = screen.getByText("Lowest total");
+    expect(badge.closest('[data-slot="card-header"]')).toBeNull();
+  });
+
   it("renders the Lowest total badge on its own line, not inline with the card title", () => {
     render(
       <SummaryCards

--- a/src/__tests__/summary-cards.test.tsx
+++ b/src/__tests__/summary-cards.test.tsx
@@ -127,6 +127,23 @@ describe("SummaryCards", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses xl (not lg) breakpoint for 4-column layout to avoid overflow inside the split-pane right pane", () => {
+    render(
+      <SummaryCards
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    const grid = screen
+      .getByText("VDC Vault Foundation")
+      .closest('[data-slot="card"]')?.parentElement;
+
+    expect(grid?.className).not.toMatch(/lg:grid-cols-4/);
+    expect(grid?.className).toMatch(/xl:grid-cols-4/);
+  });
+
   it("shows ZRS not available text and excludes it from cheapest when option1 unavailable", () => {
     render(
       <SummaryCards

--- a/src/__tests__/term-selector.test.tsx
+++ b/src/__tests__/term-selector.test.tsx
@@ -18,6 +18,15 @@ describe("TermSelector", () => {
     expect(screen.getByRole("radio", { name: "5 Years" })).toBeInTheDocument();
   });
 
+  it("allows term buttons to wrap at all viewport sizes (no forced md:flex-nowrap)", () => {
+    render(<TermSelector onTermChange={vi.fn()} />);
+
+    const radiogroup = screen.getByRole("radiogroup", {
+      name: /commitment term/i,
+    });
+    expect(radiogroup.className).not.toMatch(/md:flex-nowrap/);
+  });
+
   it("supports keyboard navigation with arrow keys and reports changes", () => {
     const onTermChange = vi.fn();
     render(<TermSelector onTermChange={onTermChange} />);

--- a/src/__tests__/term-selector.test.tsx
+++ b/src/__tests__/term-selector.test.tsx
@@ -18,6 +18,15 @@ describe("TermSelector", () => {
     expect(screen.getByRole("radio", { name: "5 Years" })).toBeInTheDocument();
   });
 
+  it("lays out term buttons in a 5-column grid so all options are always on one row", () => {
+    render(<TermSelector onTermChange={vi.fn()} />);
+
+    const radiogroup = screen.getByRole("radiogroup", {
+      name: /commitment term/i,
+    });
+    expect(radiogroup.className).toMatch(/grid-cols-5/);
+  });
+
   it("uses gap-3 on the fieldset so the legend-to-radiogroup spacing matches other form field labels", () => {
     const { container } = render(<TermSelector onTermChange={vi.fn()} />);
 

--- a/src/__tests__/term-selector.test.tsx
+++ b/src/__tests__/term-selector.test.tsx
@@ -18,6 +18,13 @@ describe("TermSelector", () => {
     expect(screen.getByRole("radio", { name: "5 Years" })).toBeInTheDocument();
   });
 
+  it("uses gap-3 on the fieldset so the legend-to-radiogroup spacing matches other form field labels", () => {
+    const { container } = render(<TermSelector onTermChange={vi.fn()} />);
+
+    const fieldset = container.querySelector("fieldset");
+    expect(fieldset?.className).toMatch(/gap-3/);
+  });
+
   it("term buttons have no forced minimum width that causes the last button to expand full-width when wrapping", () => {
     render(<TermSelector onTermChange={vi.fn()} />);
 

--- a/src/__tests__/term-selector.test.tsx
+++ b/src/__tests__/term-selector.test.tsx
@@ -18,6 +18,14 @@ describe("TermSelector", () => {
     expect(screen.getByRole("radio", { name: "5 Years" })).toBeInTheDocument();
   });
 
+  it("term buttons have no forced minimum width that causes the last button to expand full-width when wrapping", () => {
+    render(<TermSelector onTermChange={vi.fn()} />);
+
+    for (const button of screen.getAllByRole("radio")) {
+      expect(button.className).not.toMatch(/min-w-\[calc\(50%/);
+    }
+  });
+
   it("allows term buttons to wrap at all viewport sizes (no forced md:flex-nowrap)", () => {
     render(<TermSelector onTermChange={vi.fn()} />);
 

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -102,35 +102,29 @@ export function CalculatorForm({
       <CardContent className="py-6">
         <form
           aria-label="Vault pricing inputs"
-          className="grid gap-5 lg:grid-cols-2 lg:items-start"
+          className="grid gap-5"
           onSubmit={(e) => e.preventDefault()}
         >
-          <div className="lg:col-span-2">
-            <RegionSelector
-              regions={regions}
-              isLoading={isLoading}
-              selectedRegion={selectedRegion}
-              onRegionChange={handleRegionChange}
-            />
-          </div>
+          <RegionSelector
+            regions={regions}
+            isLoading={isLoading}
+            selectedRegion={selectedRegion}
+            onRegionChange={handleRegionChange}
+          />
           <TermSelector value={termYears} onTermChange={setTermYears} />
           <CapacityInput
             value={capacityTiB}
             onCapacityChange={setCapacityTiB}
           />
-          <div className="lg:col-span-2">
-            <RestorePercentageSlider
-              value={restorePercentage}
-              capacityTiB={capacityTiB}
-              onValueChange={setRestorePercentage}
-            />
-          </div>
-          <div className="lg:col-span-2">
-            <EgressToggle
-              checked={excludeEgress}
-              onCheckedChange={setExcludeEgress}
-            />
-          </div>
+          <RestorePercentageSlider
+            value={restorePercentage}
+            capacityTiB={capacityTiB}
+            onValueChange={setRestorePercentage}
+          />
+          <EgressToggle
+            checked={excludeEgress}
+            onCheckedChange={setExcludeEgress}
+          />
         </form>
       </CardContent>
     </Card>

--- a/src/components/calculator/term-selector.tsx
+++ b/src/components/calculator/term-selector.tsx
@@ -57,7 +57,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
       <div
         role="radiogroup"
         aria-labelledby={TERM_LABEL_ID}
-        className="border-border/70 flex flex-wrap gap-2 rounded-2xl border bg-[color:var(--card-tint-neutral)]/70 p-2"
+        className="border-border/70 grid grid-cols-5 gap-2 rounded-2xl border bg-[color:var(--card-tint-neutral)]/70 p-2"
       >
         {TERM_OPTIONS.map((years) => {
           const isSelected = years === selectedValue;
@@ -73,7 +73,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
               onClick={() => onTermChange(years)}
               onKeyDown={(event) => handleArrowNavigation(event, years)}
               className={cn(
-                "flex-1 rounded-xl border px-3 py-2 text-sm font-medium transition-colors",
+                "rounded-xl border px-3 py-2 text-center text-sm font-medium transition-colors",
                 isSelected
                   ? "bg-background text-foreground border-[color:var(--viridis)]/30 shadow-[0_10px_30px_-18px_var(--viridis)]"
                   : "text-muted-foreground hover:bg-background/70 hover:text-foreground border-transparent bg-transparent",

--- a/src/components/calculator/term-selector.tsx
+++ b/src/components/calculator/term-selector.tsx
@@ -50,7 +50,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
   };
 
   return (
-    <fieldset className="grid gap-2">
+    <fieldset className="grid gap-3">
       <legend id={TERM_LABEL_ID} className="text-sm leading-none font-medium">
         Commitment term
       </legend>

--- a/src/components/calculator/term-selector.tsx
+++ b/src/components/calculator/term-selector.tsx
@@ -73,7 +73,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
               onClick={() => onTermChange(years)}
               onKeyDown={(event) => handleArrowNavigation(event, years)}
               className={cn(
-                "min-w-[calc(50%-0.25rem)] flex-1 rounded-xl border px-3 py-2 text-sm font-medium transition-colors md:min-w-0",
+                "flex-1 rounded-xl border px-3 py-2 text-sm font-medium transition-colors",
                 isSelected
                   ? "bg-background text-foreground border-[color:var(--viridis)]/30 shadow-[0_10px_30px_-18px_var(--viridis)]"
                   : "text-muted-foreground hover:bg-background/70 hover:text-foreground border-transparent bg-transparent",

--- a/src/components/calculator/term-selector.tsx
+++ b/src/components/calculator/term-selector.tsx
@@ -57,7 +57,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
       <div
         role="radiogroup"
         aria-labelledby={TERM_LABEL_ID}
-        className="border-border/70 flex flex-wrap gap-2 rounded-2xl border bg-[color:var(--card-tint-neutral)]/70 p-2 md:flex-nowrap"
+        className="border-border/70 flex flex-wrap gap-2 rounded-2xl border bg-[color:var(--card-tint-neutral)]/70 p-2"
       >
         {TERM_OPTIONS.map((years) => {
           const isSelected = years === selectedValue;

--- a/src/components/results/summary-cards.tsx
+++ b/src/components/results/summary-cards.tsx
@@ -160,17 +160,15 @@ export function SummaryCards({
                 "bg-card-tint-success border-t-2 border-[color:var(--success)]/25 border-t-[color:var(--viridis)]/60 shadow-[0_24px_72px_-48px_color-mix(in_oklab,var(--success)_50%,transparent)]",
             )}
           >
-            <CardHeader className="gap-3">
-              <div className="flex items-start justify-between gap-3">
-                <CardTitle className="text-base leading-6 tracking-[-0.03em]">
-                  {card.title}
-                </CardTitle>
-                {isCheapest ? (
-                  <Badge className="rounded-full border border-[color:var(--success)]/20 bg-[color:var(--success-muted)] px-2.5 py-1 font-mono text-[0.65rem] tracking-[0.16em] text-[color:var(--dark-mineral)] uppercase">
-                    Lowest total
-                  </Badge>
-                ) : null}
-              </div>
+            <CardHeader className="gap-2">
+              <CardTitle className="text-base leading-6 tracking-[-0.03em]">
+                {card.title}
+              </CardTitle>
+              {isCheapest ? (
+                <Badge className="self-start rounded-full border border-[color:var(--success)]/20 bg-[color:var(--success-muted)] px-2.5 py-1 font-mono text-[0.65rem] tracking-[0.16em] text-[color:var(--dark-mineral)] uppercase">
+                  Lowest total
+                </Badge>
+              ) : null}
             </CardHeader>
             <CardContent className="space-y-3">
               <p className="dark:text-foreground text-2xl font-semibold tracking-[-0.05em] text-[color:var(--dark-mineral)] [font-variant-numeric:tabular-nums]">

--- a/src/components/results/summary-cards.tsx
+++ b/src/components/results/summary-cards.tsx
@@ -160,15 +160,10 @@ export function SummaryCards({
                 "bg-card-tint-success border-t-2 border-[color:var(--success)]/25 border-t-[color:var(--viridis)]/60 shadow-[0_24px_72px_-48px_color-mix(in_oklab,var(--success)_50%,transparent)]",
             )}
           >
-            <CardHeader className="gap-2">
+            <CardHeader>
               <CardTitle className="text-base leading-6 tracking-[-0.03em]">
                 {card.title}
               </CardTitle>
-              {isCheapest ? (
-                <Badge className="self-start rounded-full border border-[color:var(--success)]/20 bg-[color:var(--success-muted)] px-2.5 py-1 font-mono text-[0.65rem] tracking-[0.16em] text-[color:var(--dark-mineral)] uppercase">
-                  Lowest total
-                </Badge>
-              ) : null}
             </CardHeader>
             <CardContent className="space-y-3">
               <p className="dark:text-foreground text-2xl font-semibold tracking-[-0.05em] text-[color:var(--dark-mineral)] [font-variant-numeric:tabular-nums]">
@@ -190,6 +185,11 @@ export function SummaryCards({
                   )}
                 </p>
               </div>
+              {isCheapest ? (
+                <Badge className="self-start rounded-full border border-[color:var(--success)]/20 bg-[color:var(--success-muted)] px-2.5 py-1 font-mono text-[0.65rem] tracking-[0.16em] text-[color:var(--dark-mineral)] uppercase">
+                  Lowest total
+                </Badge>
+              ) : null}
             </CardContent>
           </Card>
         );

--- a/src/components/results/summary-cards.tsx
+++ b/src/components/results/summary-cards.tsx
@@ -135,7 +135,7 @@ export function SummaryCards({
   }, null);
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
       {cards.map((card, index) => {
         const isCheapest =
           cheapestTotal !== null && card.total === cheapestTotal;


### PR DESCRIPTION
## Summary

Implements the split-pane dashboard layout from #46, plus a series of visual polish fixes surfaced during review and QA.

### Core layout (`App.tsx`)
- Replaces the single `flex-col` stack with a persistent two-pane `flex-row` layout at the `lg` (1024px) breakpoint
- Left pane (~28%): sticky `CalculatorForm` sidebar — inputs always visible while results scroll
- Right pane (`flex-1`): scrollable results dashboard (`aria-live` region, `ResultsPanel`, alerts)
- Below `lg`: stacked layout unchanged (mobile/tablet unaffected)
- `max-w-5xl` widened to `max-w-7xl` to match header/footer container width

### Visual fixes (post-split-pane QA)
- **`CalculatorForm`**: removed `lg:grid-cols-2` — two columns overflowed the narrow sidebar
- **`SummaryCards`**: `lg:grid-cols-4` → `xl:grid-cols-4` — four columns overflowed the right pane at `lg`
- **`TermSelector`**: replaced `flex flex-wrap` with `grid grid-cols-5` so all five term buttons always sit on one row; removed `md:flex-nowrap` and `min-w` constraints that caused the last button to expand full-width when wrapping; bumped fieldset `gap-2` → `gap-3` to match the visual label spacing of adjacent form fields
- **`SummaryCards` badge**: moved "Lowest total" badge from `CardHeader` (where it competed with the title) to the bottom of `CardContent`, so title rows align horizontally across all four cards

### Code review fixes
- Moved `Lowest total` badge outside `justify-between` container to prevent overflow at narrow card widths
- Replaced fragile `firstElementChild?.className` assertion in `app.test.tsx` with `form.closest('[class*="..."]')`, consistent with the sibling sticky test

## Test plan

- [x] 324 tests pass (`npm run test:run`) — up from 317 at branch start
- [x] Lint clean (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [ ] Visual QA at `npm run preview`: lg+ shows side-by-side with sticky sidebar; <lg shows stacked; term buttons stay on one row; summary cards show 2 columns at lg, 4 at xl

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)