### PR TITLE
feat(ui): apply font-mono to dollar figures in summary cards and breakdown table

### DIFF
--- a/src/__tests__/cost-breakdown-table.test.tsx
+++ b/src/__tests__/cost-breakdown-table.test.tsx
@@ -206,6 +206,14 @@ describe("CostBreakdownTable", () => {
     ).toBeInTheDocument();
   });
 
+  it("applies font-mono to non-category data cells", () => {
+    render(<CostBreakdownTable comparison={fixtureComparison} />);
+
+    // $5,040.00 appears in both the Storage body row and the footer Total row
+    const cells = screen.getAllByText("$5,040.00");
+    cells.forEach((cell) => expect(cell).toHaveClass("font-mono"));
+  });
+
   it("overage row shows '--' for Advanced and DIY columns", () => {
     render(
       <CostBreakdownTable

--- a/src/__tests__/summary-cards.test.tsx
+++ b/src/__tests__/summary-cards.test.tsx
@@ -170,6 +170,30 @@ describe("SummaryCards", () => {
     expect(grid?.className).toMatch(/xl:grid-cols-4/);
   });
 
+  it("applies font-mono to the total value", () => {
+    render(
+      <SummaryCards
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    expect(screen.getByText("$5,040.00")).toHaveClass("font-mono");
+  });
+
+  it("applies font-mono to the effective rate value", () => {
+    render(
+      <SummaryCards
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    expect(screen.getByText("$14/TB/mo")).toHaveClass("font-mono");
+  });
+
   it("shows ZRS not available text and excludes it from cheapest when option1 unavailable", () => {
     render(
       <SummaryCards

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -136,28 +136,30 @@ export function CostBreakdownTable({
             {data.map((row) => (
               <TableRow key={row.category}>
                 <TableCell>{row.category}</TableCell>
-                <TableCell>{row.foundation}</TableCell>
-                <TableCell>{row.advanced}</TableCell>
-                <TableCell>{row.diyOption1}</TableCell>
-                <TableCell>{row.diyOption2}</TableCell>
+                <TableCell className="font-mono">{row.foundation}</TableCell>
+                <TableCell className="font-mono">{row.advanced}</TableCell>
+                <TableCell className="font-mono">{row.diyOption1}</TableCell>
+                <TableCell className="font-mono">{row.diyOption2}</TableCell>
               </TableRow>
             ))}
           </TableBody>
           <TableFooter>
             <TableRow>
               <TableCell>Total</TableCell>
-              <TableCell>
+              <TableCell className="font-mono">
                 {formatVaultTotal(comparison.vaultFoundation)}
               </TableCell>
-              <TableCell>
+              <TableCell className="font-mono">
                 {formatVaultTotal(comparison.vaultAdvanced)}
               </TableCell>
-              <TableCell>
+              <TableCell className="font-mono">
                 {comparison.diyOption1Unavailable
                   ? "N/A"
                   : formatUSD(comparison.diyOption1.total)}
               </TableCell>
-              <TableCell>{formatUSD(comparison.diyOption2.total)}</TableCell>
+              <TableCell className="font-mono">
+                {formatUSD(comparison.diyOption2.total)}
+              </TableCell>
             </TableRow>
           </TableFooter>
         </Table>

--- a/src/components/results/summary-cards.tsx
+++ b/src/components/results/summary-cards.tsx
@@ -166,7 +166,7 @@ export function SummaryCards({
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              <p className="dark:text-foreground text-2xl font-semibold tracking-[-0.05em] text-[color:var(--dark-mineral)] [font-variant-numeric:tabular-nums]">
+              <p className="dark:text-foreground font-mono text-2xl font-semibold tracking-[-0.05em] text-[color:var(--dark-mineral)] [font-variant-numeric:tabular-nums]">
                 {formatTotalValue(
                   card.total,
                   card.pricingTbd,
@@ -177,7 +177,7 @@ export function SummaryCards({
                 <p className="text-muted-foreground font-mono text-[0.68rem] tracking-[0.2em] uppercase">
                   Effective rate
                 </p>
-                <p className="text-sm font-medium">
+                <p className="font-mono text-sm font-medium">
                   {formatRateValue(
                     card.rate,
                     card.pricingTbd,


### PR DESCRIPTION
## Summary

- Adds `font-mono` (Geist Mono) to the total-value `<p>` in `SummaryCards` so dollar amounts read as precision calculated readouts rather than body text
- Applies the same treatment to the "Effective rate" value `<p>` in `SummaryCards`
- Adds `font-mono` to non-category data cells in `CostBreakdownTable` (body rows + footer) for visual consistency across the results UI
- No new dependencies — Geist Mono is already loaded via `--font-mono` in `index.css`

## Test plan

- [x] 3 new TDD tests added (red before implementation, green after): `SummaryCards > applies font-mono to the total value`, `SummaryCards > applies font-mono to the effective rate value`, `CostBreakdownTable > applies font-mono to non-category data cells`
- [x] Full test suite passes: 327/327
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)