### PR TITLE
feat(ui): replace diffuse card shadows with sharp 1px borders

### DIFF
--- a/src/__tests__/card-borders.test.tsx
+++ b/src/__tests__/card-borders.test.tsx
@@ -1,0 +1,37 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  FIXTURE_CAPACITY_TIB,
+  FIXTURE_TERM_YEARS,
+  fixtureComparison,
+} from "@/__tests__/fixtures/comparison-result";
+import { ResultsPanel } from "@/components/results/results-panel";
+
+function collectClassTokens() {
+  return Array.from(document.body.querySelectorAll("[class]")).flatMap((el) =>
+    (el.getAttribute("class") ?? "").split(/\s+/).filter(Boolean),
+  );
+}
+
+// Matches the large diffuse card shadows: shadow-[0_Npx_Npx_-Npx_color-mix(...)]
+const diffuseShadowPattern = /^shadow-\[0_\d+px_\d+px_-\d+px_color-mix/;
+
+describe("card borders", () => {
+  it("renders card components without large diffuse shadows", () => {
+    render(
+      <ResultsPanel
+        comparison={fixtureComparison}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+        restorePercentage={20}
+      />,
+    );
+
+    const diffuseShadowTokens = collectClassTokens().filter((t) =>
+      diffuseShadowPattern.test(t),
+    );
+
+    expect(diffuseShadowTokens).toEqual([]);
+  });
+});

--- a/src/__tests__/card-borders.test.tsx
+++ b/src/__tests__/card-borders.test.tsx
@@ -1,12 +1,19 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   FIXTURE_CAPACITY_TIB,
   FIXTURE_TERM_YEARS,
   fixtureComparison,
 } from "@/__tests__/fixtures/comparison-result";
+import { CalculatorForm } from "@/components/calculator/calculator-form";
 import { ResultsPanel } from "@/components/results/results-panel";
+
+vi.mock("@/hooks/use-regions", () => ({
+  useRegions: vi
+    .fn()
+    .mockReturnValue({ regions: [], isLoading: false, error: null }),
+}));
 
 function collectClassTokens() {
   return Array.from(document.body.querySelectorAll("[class]")).flatMap((el) =>
@@ -20,12 +27,15 @@ const diffuseShadowPattern = /^shadow-\[0_\d+px_\d+px_-\d+px_color-mix/;
 describe("card borders", () => {
   it("renders card components without large diffuse shadows", () => {
     render(
-      <ResultsPanel
-        comparison={fixtureComparison}
-        capacityTiB={FIXTURE_CAPACITY_TIB}
-        termYears={FIXTURE_TERM_YEARS}
-        restorePercentage={20}
-      />,
+      <>
+        <CalculatorForm onInputsChange={vi.fn()} />
+        <ResultsPanel
+          comparison={fixtureComparison}
+          capacityTiB={FIXTURE_CAPACITY_TIB}
+          termYears={FIXTURE_TERM_YEARS}
+          restorePercentage={20}
+        />
+      </>,
     );
 
     const diffuseShadowTokens = collectClassTokens().filter((t) =>

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -89,7 +89,7 @@ export function CalculatorForm({
   }, [completeInputs, onInputsChange]);
 
   return (
-    <Card className="border-border/70 bg-background/90 overflow-hidden rounded-[1.75rem] shadow-[0_32px_100px_-56px_color-mix(in_oklab,var(--electric-azure)_75%,transparent)] backdrop-blur">
+    <Card className="border-border/50 bg-background/90 overflow-hidden rounded-[1.75rem] backdrop-blur">
       <CardHeader className="border-border/70 gap-3 border-b bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Calculation inputs

--- a/src/components/results/comparison-chart.tsx
+++ b/src/components/results/comparison-chart.tsx
@@ -227,7 +227,7 @@ export function ComparisonChart({ comparison }: ComparisonChartProps) {
   const data = buildChartData(comparison);
 
   return (
-    <Card className="border-border/70 bg-background/90 rounded-[1.75rem] shadow-[0_32px_100px_-56px_color-mix(in_oklab,var(--electric-azure)_75%,transparent)]">
+    <Card className="border-border/50 bg-background/90 rounded-[1.75rem]">
       <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Cost comparison

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -111,7 +111,7 @@ export function CostBreakdownTable({
   }, [comparison, excludeEgress]);
 
   return (
-    <Card className="border-border/70 bg-background/90 rounded-[1.75rem] shadow-[0_32px_100px_-56px_color-mix(in_oklab,var(--electric-azure)_75%,transparent)]">
+    <Card className="border-border/50 bg-background/90 rounded-[1.75rem]">
       <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Cost breakdown

--- a/src/components/results/cost-trend-chart.tsx
+++ b/src/components/results/cost-trend-chart.tsx
@@ -165,7 +165,7 @@ export function CostTrendChart({ comparison, termYears }: CostTrendChartProps) {
   const showDiy1 = !comparison.diyOption1Unavailable;
 
   return (
-    <Card className="border-border/70 bg-background/90 rounded-[1.75rem] shadow-[0_32px_100px_-56px_color-mix(in_oklab,var(--electric-azure)_75%,transparent)]">
+    <Card className="border-border/50 bg-background/90 rounded-[1.75rem]">
       <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Cost over time

--- a/src/components/results/summary-cards.tsx
+++ b/src/components/results/summary-cards.tsx
@@ -149,7 +149,7 @@ export function SummaryCards({
             key={card.id}
             style={{ animationDelay: `${index * 80}ms` }}
             className={cn(
-              "border-border/70 bg-background/90 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 rounded-[1.5rem] shadow-[0_24px_72px_-48px_color-mix(in_oklab,var(--electric-azure)_60%,transparent)] motion-safe:duration-500",
+              "border-border/50 bg-background/90 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 rounded-[1.5rem] motion-safe:duration-500",
               isVault &&
                 !isCheapest &&
                 "border-t-2 border-t-[color:var(--viridis)]/40",
@@ -157,7 +157,7 @@ export function SummaryCards({
                 !isCheapest &&
                 "border-t-2 border-t-[color:var(--electric-azure)]/35",
               isCheapest &&
-                "bg-card-tint-success border-t-2 border-[color:var(--success)]/25 border-t-[color:var(--viridis)]/60 shadow-[0_24px_72px_-48px_color-mix(in_oklab,var(--success)_50%,transparent)]",
+                "bg-card-tint-success border-t-2 border-[color:var(--success)]/25 border-t-[color:var(--viridis)]/60",
             )}
           >
             <CardHeader>


### PR DESCRIPTION
## Summary

- Removes large diffuse `color-mix` box-shadows from all four main card components: `calculator-form`, `summary-cards`, `comparison-chart`, `cost-breakdown-table`
- Softens the existing `border-border` token from `/70` → `/50` across those cards for a crisper 1px edge
- Preserves the coloured `border-t-2` accents on summary cards (Vault green / DIY blue / cheapest success)
- Adds `card-borders.test.tsx` using the `collectClassTokens` pattern (same approach as `reduced-motion.test.tsx`) to prevent regression

Closes #48

## Test plan

- [x] `npm run test:run` — 328 tests pass (new `card-borders` test green)
- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds
- [ ] `npm run preview` — visual QA: crisp 1px borders, no glow/blur, `border-t-2` accents visible, both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)