### PR TITLE
fix(ui): remove white gap above gradient card headers

### DIFF
--- a/src/__tests__/card-borders.test.tsx
+++ b/src/__tests__/card-borders.test.tsx
@@ -53,8 +53,9 @@ describe("card borders", () => {
 
     gradientHeaders.forEach((header) => {
       const card = header.parentElement;
-      expect(card?.className).toMatch(/\bpt-0\b/);
-      expect(card?.className).toMatch(/\boverflow-hidden\b/);
+      expect(card).not.toBeNull();
+      expect(card!.className).toMatch(/\bpt-0\b/);
+      expect(card!.className).toMatch(/\boverflow-hidden\b/);
     });
   });
 

--- a/src/__tests__/card-borders.test.tsx
+++ b/src/__tests__/card-borders.test.tsx
@@ -25,6 +25,33 @@ function collectClassTokens() {
 const diffuseShadowPattern = /^shadow-\[0_\d+px_\d+px_-\d+px_color-mix/;
 
 describe("card borders", () => {
+  it("gradient-header card wrappers have pt-0 and overflow-hidden to eliminate the white gap", () => {
+    render(
+      <>
+        <CalculatorForm onInputsChange={vi.fn()} />
+        <ResultsPanel
+          comparison={fixtureComparison}
+          capacityTiB={FIXTURE_CAPACITY_TIB}
+          termYears={FIXTURE_TERM_YEARS}
+          restorePercentage={20}
+        />
+      </>,
+    );
+
+    const gradientHeaders = Array.from(
+      document.body.querySelectorAll<HTMLElement>(
+        '[class*="surface-gradient"]',
+      ),
+    );
+    expect(gradientHeaders.length).toBeGreaterThanOrEqual(2);
+
+    gradientHeaders.forEach((header) => {
+      const card = header.parentElement;
+      expect(card?.className).toMatch(/\bpt-0\b/);
+      expect(card?.className).toMatch(/\boverflow-hidden\b/);
+    });
+  });
+
   it("renders card components without large diffuse shadows", () => {
     render(
       <>

--- a/src/__tests__/card-borders.test.tsx
+++ b/src/__tests__/card-borders.test.tsx
@@ -7,6 +7,9 @@ import {
   fixtureComparison,
 } from "@/__tests__/fixtures/comparison-result";
 import { CalculatorForm } from "@/components/calculator/calculator-form";
+import { ComparisonChart } from "@/components/results/comparison-chart";
+import { CostBreakdownTable } from "@/components/results/cost-breakdown-table";
+import { CostTrendChart } from "@/components/results/cost-trend-chart";
 import { ResultsPanel } from "@/components/results/results-panel";
 
 vi.mock("@/hooks/use-regions", () => ({
@@ -26,14 +29,17 @@ const diffuseShadowPattern = /^shadow-\[0_\d+px_\d+px_-\d+px_color-mix/;
 
 describe("card borders", () => {
   it("gradient-header card wrappers have pt-0 and overflow-hidden to eliminate the white gap", () => {
+    // Render each gradient-header card directly: ResultsPanel renders CostBreakdownTable
+    // and CostTrendChart inside inactive Radix tabs, so they are not in the DOM unless
+    // the tab is activated. Render them explicitly to cover all four cards.
     render(
       <>
         <CalculatorForm onInputsChange={vi.fn()} />
-        <ResultsPanel
+        <ComparisonChart comparison={fixtureComparison} />
+        <CostBreakdownTable comparison={fixtureComparison} />
+        <CostTrendChart
           comparison={fixtureComparison}
-          capacityTiB={FIXTURE_CAPACITY_TIB}
           termYears={FIXTURE_TERM_YEARS}
-          restorePercentage={20}
         />
       </>,
     );
@@ -43,7 +49,7 @@ describe("card borders", () => {
         '[class*="surface-gradient"]',
       ),
     );
-    expect(gradientHeaders.length).toBeGreaterThanOrEqual(2);
+    expect(gradientHeaders).toHaveLength(4);
 
     gradientHeaders.forEach((header) => {
       const card = header.parentElement;

--- a/src/components/calculator/calculator-form.tsx
+++ b/src/components/calculator/calculator-form.tsx
@@ -89,7 +89,7 @@ export function CalculatorForm({
   }, [completeInputs, onInputsChange]);
 
   return (
-    <Card className="border-border/50 bg-background/90 overflow-hidden rounded-[1.75rem] backdrop-blur">
+    <Card className="border-border/50 bg-background/90 overflow-hidden rounded-[1.75rem] pt-0 backdrop-blur">
       <CardHeader className="border-border/70 gap-3 border-b bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Calculation inputs

--- a/src/components/results/comparison-chart.tsx
+++ b/src/components/results/comparison-chart.tsx
@@ -227,7 +227,7 @@ export function ComparisonChart({ comparison }: ComparisonChartProps) {
   const data = buildChartData(comparison);
 
   return (
-    <Card className="border-border/50 bg-background/90 rounded-[1.75rem]">
+    <Card className="border-border/50 bg-background/90 overflow-hidden rounded-[1.75rem] pt-0">
       <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Cost comparison

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -111,7 +111,7 @@ export function CostBreakdownTable({
   }, [comparison, excludeEgress]);
 
   return (
-    <Card className="border-border/50 bg-background/90 rounded-[1.75rem]">
+    <Card className="border-border/50 bg-background/90 overflow-hidden rounded-[1.75rem] pt-0">
       <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Cost breakdown

--- a/src/components/results/cost-trend-chart.tsx
+++ b/src/components/results/cost-trend-chart.tsx
@@ -165,7 +165,7 @@ export function CostTrendChart({ comparison, termYears }: CostTrendChartProps) {
   const showDiy1 = !comparison.diyOption1Unavailable;
 
   return (
-    <Card className="border-border/50 bg-background/90 rounded-[1.75rem]">
+    <Card className="border-border/50 bg-background/90 overflow-hidden rounded-[1.75rem] pt-0">
       <CardHeader className="gap-3 border-b border-[color:var(--dark-mineral)]/12 bg-[image:var(--surface-gradient)] py-5">
         <CardTitle className="text-xl tracking-[-0.03em]">
           Cost over time


### PR DESCRIPTION
## Summary

- Adds `pt-0` to both gradient-header `Card` wrappers (`CalculatorForm` and `ComparisonChart`) so the `CardHeader` sits flush with the card's top edge instead of being pushed down by the `py-6` baked into the base `Card` component
- Adds `overflow-hidden` to the `ComparisonChart` card (already present on `CalculatorForm`) so rounded corners clip the gradient cleanly
- Adds a regression test in `card-borders.test.tsx` verifying both gradient-header card wrappers carry `pt-0` and `overflow-hidden`
- Applies the same `overflow-hidden pt-0` fix to `CostBreakdownTable` ("Cost breakdown") and `CostTrendChart` ("Cost over time"), which had the identical issue
- Tightens the regression test to render all four gradient-header cards directly (inactive Radix tab content is not mounted in the DOM, so two cards were previously untested)

Closes #56

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:run` — 329 tests, all passing
- [x] `npm run build` — production build succeeds
- [ ] Visual: open dev server, confirm no white strip above green gradient in light and dark mode on all four cards (Calculation inputs, Cost comparison, Cost breakdown, Cost over time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)