### PR TITLE
feat(chart): show per-item percentage of total in comparison chart tooltip

### DIFF
--- a/src/__tests__/comparison-chart.test.tsx
+++ b/src/__tests__/comparison-chart.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { fixtureComparison } from "@/__tests__/fixtures/comparison-result";
-import { ComparisonChart } from "@/components/results/comparison-chart";
+import {
+  ChartTooltip,
+  ComparisonChart,
+} from "@/components/results/comparison-chart";
 
 describe("ComparisonChart", () => {
   it("renders an accessible responsive bar chart with four comparison labels", () => {
@@ -54,5 +57,37 @@ describe("ComparisonChart", () => {
     expect(container.querySelectorAll(".recharts-bar-rectangle")).toHaveLength(
       10,
     );
+  });
+});
+
+describe("ChartTooltip percentage display", () => {
+  // Fixture mirrors diyOption1 from fixtureComparison: total = 9000
+  const diyPayload = [
+    { name: "Storage", value: 7200, fill: "#aaa" },
+    { name: "Write Operations", value: 900, fill: "#bbb" },
+    { name: "Read Operations", value: 300, fill: "#ccc" },
+    { name: "Data Retrieval", value: 200, fill: "#ddd" },
+    { name: "Internet Egress", value: 400, fill: "#eee" },
+  ];
+
+  it("shows rounded integer percentage suffix on each DIY tooltip row", () => {
+    render(<ChartTooltip active label="S3 Standard" payload={diyPayload} />);
+    // 7200/9000=80%, 900/9000=10%, 300/9000=3%, 200/9000=2%, 400/9000=4%
+    expect(screen.getByText("(80%)")).toBeInTheDocument();
+    expect(screen.getByText("(10%)")).toBeInTheDocument();
+    expect(screen.getByText("(3%)")).toBeInTheDocument();
+    expect(screen.getByText("(2%)")).toBeInTheDocument();
+    expect(screen.getByText("(4%)")).toBeInTheDocument();
+  });
+
+  it("omits percentage suffix for single-segment Vault tooltip rows", () => {
+    render(
+      <ChartTooltip
+        active
+        label="VDC Vault Foundation"
+        payload={[{ name: "VDC Vault Foundation", value: 5040, fill: "#0f0" }]}
+      />,
+    );
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/results/comparison-chart.tsx
+++ b/src/components/results/comparison-chart.tsx
@@ -140,7 +140,7 @@ function numericValue(value: TooltipEntry["value"]): number {
   return typeof value === "number" ? value : 0;
 }
 
-function ChartTooltip({
+export function ChartTooltip({
   active,
   payload,
   label,
@@ -153,6 +153,9 @@ function ChartTooltip({
 
   const entries = payload.filter((e) => numericValue(e.value) > 0);
   if (!entries.length) return null;
+
+  const total = entries.reduce((sum, e) => sum + numericValue(e.value), 0);
+  const showPct = entries.length > 1;
 
   return (
     <div className="border-border/80 bg-card rounded-2xl border p-3 shadow-lg">
@@ -173,6 +176,11 @@ function ChartTooltip({
               style={{ color: entry.fill }}
             >
               {formatUSD(numericValue(entry.value))}
+              {showPct && (
+                <span className="text-muted-foreground ml-1.5 font-normal">
+                  ({Math.round((numericValue(entry.value) / total) * 100)}%)
+                </span>
+              )}
             </span>
           </div>
         ))}


### PR DESCRIPTION
## Summary

- DIY stacked-bar tooltip rows now display `$X,XXX.XX (XX%)`, where the percentage is the component's share of that bar's total, rounded to the nearest integer
- Vault bars (single segment) are unchanged — no percentage suffix is rendered when there is only one non-zero entry in the payload
- `ChartTooltip` is exported so it can be tested in isolation without full chart rendering

## Changes

- `src/components/results/comparison-chart.tsx` — add percentage logic to `ChartTooltip`; export it for testing
- `src/__tests__/comparison-chart.test.tsx` — two new tests covering DIY percentage display and Vault suppression

## Test plan

- [x] `npm run test:run` — 331 tests pass (2 new, 0 regressions)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)