### PR TITLE
fix(ui): centre term selector button text with explicit two-line layout

### DIFF
--- a/src/__tests__/term-selector.test.tsx
+++ b/src/__tests__/term-selector.test.tsx
@@ -51,6 +51,25 @@ describe("TermSelector", () => {
     expect(radiogroup.className).not.toMatch(/md:flex-nowrap/);
   });
 
+  it("uses flex column layout on term buttons to ensure consistent vertical centering", () => {
+    render(<TermSelector onTermChange={vi.fn()} />);
+    for (const button of screen.getAllByRole("radio")) {
+      expect(button.className).toMatch(/flex/);
+      expect(button.className).toMatch(/flex-col/);
+      expect(button.className).toMatch(/items-center/);
+      expect(button.className).toMatch(/justify-center/);
+    }
+  });
+
+  it("renders number and label in separate spans for explicit two-line layout", () => {
+    render(<TermSelector onTermChange={vi.fn()} />);
+    const oneYearButton = screen.getByRole("radio", { name: "1 Year" });
+    const spans = oneYearButton.querySelectorAll("span");
+    expect(spans).toHaveLength(2);
+    expect(spans[0]).toHaveTextContent("1");
+    expect(spans[1]).toHaveTextContent("Year");
+  });
+
   it("supports keyboard navigation with arrow keys and reports changes", () => {
     const onTermChange = vi.fn();
     render(<TermSelector onTermChange={onTermChange} />);

--- a/src/__tests__/term-selector.test.tsx
+++ b/src/__tests__/term-selector.test.tsx
@@ -63,11 +63,18 @@ describe("TermSelector", () => {
 
   it("renders number and label in separate spans for explicit two-line layout", () => {
     render(<TermSelector onTermChange={vi.fn()} />);
+
     const oneYearButton = screen.getByRole("radio", { name: "1 Year" });
-    const spans = oneYearButton.querySelectorAll("span");
-    expect(spans).toHaveLength(2);
-    expect(spans[0]).toHaveTextContent("1");
-    expect(spans[1]).toHaveTextContent("Year");
+    const singularSpans = oneYearButton.querySelectorAll("span");
+    expect(singularSpans).toHaveLength(2);
+    expect(singularSpans[0]).toHaveTextContent("1");
+    expect(singularSpans[1]).toHaveTextContent("Year");
+
+    const threeYearsButton = screen.getByRole("radio", { name: "3 Years" });
+    const pluralSpans = threeYearsButton.querySelectorAll("span");
+    expect(pluralSpans).toHaveLength(2);
+    expect(pluralSpans[0]).toHaveTextContent("3");
+    expect(pluralSpans[1]).toHaveTextContent("Years");
   });
 
   it("supports keyboard navigation with arrow keys and reports changes", () => {

--- a/src/components/calculator/term-selector.tsx
+++ b/src/components/calculator/term-selector.tsx
@@ -72,14 +72,16 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
               tabIndex={isSelected ? 0 : -1}
               onClick={() => onTermChange(years)}
               onKeyDown={(event) => handleArrowNavigation(event, years)}
+              aria-label={`${years} ${years === 1 ? "Year" : "Years"}`}
               className={cn(
-                "rounded-xl border px-3 py-2 text-center text-sm font-medium transition-colors",
+                "flex flex-col items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition-colors",
                 isSelected
                   ? "bg-background text-foreground border-[color:var(--viridis)]/30 shadow-[0_10px_30px_-18px_var(--viridis)]"
                   : "text-muted-foreground hover:bg-background/70 hover:text-foreground border-transparent bg-transparent",
               )}
             >
-              {years} {years === 1 ? "Year" : "Years"}
+              <span>{years}</span>
+              <span>{years === 1 ? "Year" : "Years"}</span>
             </button>
           );
         })}

--- a/src/components/calculator/term-selector.tsx
+++ b/src/components/calculator/term-selector.tsx
@@ -61,6 +61,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
       >
         {TERM_OPTIONS.map((years) => {
           const isSelected = years === selectedValue;
+          const label = years === 1 ? "Year" : "Years";
 
           return (
             <button
@@ -72,7 +73,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
               tabIndex={isSelected ? 0 : -1}
               onClick={() => onTermChange(years)}
               onKeyDown={(event) => handleArrowNavigation(event, years)}
-              aria-label={`${years} ${years === 1 ? "Year" : "Years"}`}
+              aria-label={`${years} ${label}`}
               className={cn(
                 "flex flex-col items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition-colors",
                 isSelected
@@ -81,7 +82,7 @@ export function TermSelector({ value = 1, onTermChange }: TermSelectorProps) {
               )}
             >
               <span>{years}</span>
-              <span>{years === 1 ? "Year" : "Years"}</span>
+              <span>{label}</span>
             </button>
           );
         })}


### PR DESCRIPTION
## Summary

Fixes #60.

- Add `flex flex-col items-center justify-center` to each term button so the content is truly centred within its padding bounds rather than top-anchored.
- Replace the single `{years} {label}` text node with two `<span>` elements, giving the number and label explicit separate lines regardless of viewport width or font rendering.
- Add `aria-label` to each button so the accessible name (`"1 Year"`, `"2 Years"`, …) is independent of DOM structure.
- Remove redundant `text-center` (superseded by flex `items-center`).

## Test plan

- [x] Two new tests added (TDD red → green): flex layout classes present on all buttons; separate spans with correct text content.
- [x] `npm run test:run` → 333 tests pass (2 new + 331 existing)
- [x] `npm run lint` → clean
- [x] `npm run build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)