### PR TITLE
feat(chart): show Foundation restore overage breakdown in comparison chart

### DIFF
--- a/src/__tests__/comparison-chart.test.tsx
+++ b/src/__tests__/comparison-chart.test.tsx
@@ -90,4 +90,51 @@ describe("ChartTooltip percentage display", () => {
     );
     expect(screen.queryByText(/%/)).not.toBeInTheDocument();
   });
+
+  it("shows base and overage with percentages when Foundation has restore overage", () => {
+    render(
+      <ChartTooltip
+        active
+        label="VDC Vault Foundation"
+        payload={[
+          { name: "VDC Vault Foundation", value: 4200, fill: "#0f0" },
+          { name: "Restore Overage", value: 840, fill: "#f80" },
+        ]}
+      />,
+    );
+    // 4200/5040 ≈ 83%, 840/5040 ≈ 17%
+    expect(screen.getByText("(83%)")).toBeInTheDocument();
+    expect(screen.getByText("(17%)")).toBeInTheDocument();
+  });
+});
+
+describe("ComparisonChart Foundation overage", () => {
+  const comparisonWithOverage = {
+    ...fixtureComparison,
+    vaultFoundation: {
+      total: 5040,
+      perTbMonth: 14,
+      pricingTbd: false,
+      overage: 840,
+    },
+  };
+
+  it("shows Restore Overage legend entry only when Foundation overage is present", () => {
+    const { rerender } = render(
+      <ComparisonChart comparison={fixtureComparison} />,
+    );
+    expect(screen.queryByText("Restore Overage")).not.toBeInTheDocument();
+
+    rerender(<ComparisonChart comparison={comparisonWithOverage} />);
+    expect(screen.getByText("Restore Overage")).toBeInTheDocument();
+  });
+
+  it("renders an extra overage bar rectangle when Foundation overage is present", () => {
+    const { container } = render(
+      <ComparisonChart comparison={comparisonWithOverage} />,
+    );
+    expect(container.querySelectorAll(".recharts-bar-rectangle")).toHaveLength(
+      13,
+    );
+  });
 });

--- a/src/components/results/comparison-chart.tsx
+++ b/src/components/results/comparison-chart.tsx
@@ -24,7 +24,8 @@ interface ComparisonChartProps {
 
 interface ChartDatum {
   label: string;
-  vaultFoundation: number;
+  vaultFoundationBase: number;
+  vaultFoundationOverage: number;
   vaultAdvanced: number;
   storage: number;
   writeOps: number;
@@ -41,7 +42,11 @@ const DIY_LEGEND_ITEMS: Array<{ name: string; fill: string }> = [
   { name: "Internet Egress", fill: "var(--ignis)" },
 ];
 
-const VAULT_ZERO = { vaultFoundation: 0, vaultAdvanced: 0 };
+const VAULT_ZERO = {
+  vaultFoundationBase: 0,
+  vaultFoundationOverage: 0,
+  vaultAdvanced: 0,
+};
 const DIY_ZERO = {
   storage: 0,
   writeOps: 0,
@@ -54,10 +59,13 @@ function buildChartData(comparison: ComparisonResult): ChartDatum[] {
   const data: ChartDatum[] = [];
 
   if (comparison.vaultFoundation.total !== null) {
+    const overage = comparison.vaultFoundation.overage ?? 0;
+    const base = comparison.vaultFoundation.total - overage;
     data.push({
       label: "VDC Vault Foundation",
       ...VAULT_ZERO,
-      vaultFoundation: comparison.vaultFoundation.total,
+      vaultFoundationBase: base,
+      vaultFoundationOverage: overage,
       ...DIY_ZERO,
     });
   }
@@ -103,8 +111,11 @@ interface ChartLegendProps {
 function ChartLegend({ data }: ChartLegendProps) {
   const vaultItems: Array<{ name: string; fill: string }> = [];
 
-  if (data.some((d) => d.vaultFoundation > 0)) {
+  if (data.some((d) => d.vaultFoundationBase > 0)) {
     vaultItems.push({ name: "VDC Vault Foundation", fill: "var(--success)" });
+  }
+  if (data.some((d) => d.vaultFoundationOverage > 0)) {
+    vaultItems.push({ name: "Restore Overage", fill: "var(--warning)" });
   }
   if (data.some((d) => d.vaultAdvanced > 0)) {
     vaultItems.push({ name: "VDC Vault Advanced", fill: "var(--info)" });
@@ -288,10 +299,18 @@ export function ComparisonChart({ comparison }: ComparisonChartProps) {
                * DIY rows have only storage/writeOps/etc non-zero.
                */}
               <Bar
-                dataKey="vaultFoundation"
+                dataKey="vaultFoundationBase"
                 name="VDC Vault Foundation"
                 stackId="cost"
                 fill="var(--success)"
+                legendType="none"
+                radius={[6, 6, 0, 0]}
+              />
+              <Bar
+                dataKey="vaultFoundationOverage"
+                name="Restore Overage"
+                stackId="cost"
+                fill="var(--warning)"
                 legendType="none"
                 radius={[6, 6, 0, 0]}
               />

--- a/src/components/results/comparison-chart.tsx
+++ b/src/components/results/comparison-chart.tsx
@@ -106,15 +106,19 @@ function buildChartData(comparison: ComparisonResult): ChartDatum[] {
 
 interface ChartLegendProps {
   data: ChartDatum[];
+  hasFoundationOverage: boolean;
 }
 
-function ChartLegend({ data }: ChartLegendProps) {
+function ChartLegend({ data, hasFoundationOverage }: ChartLegendProps) {
   const vaultItems: Array<{ name: string; fill: string }> = [];
 
   if (data.some((d) => d.vaultFoundationBase > 0)) {
     vaultItems.push({ name: "VDC Vault Foundation", fill: "var(--success)" });
   }
-  if (data.some((d) => d.vaultFoundationOverage > 0)) {
+  if (hasFoundationOverage) {
+    // var(--warning) is also used for Data Retrieval in DIY rows; the two
+    // series never coexist in the same stacked bar, so the shared token is
+    // unambiguous in the chart itself — legend labels distinguish them.
     vaultItems.push({ name: "Restore Overage", fill: "var(--warning)" });
   }
   if (data.some((d) => d.vaultAdvanced > 0)) {
@@ -253,8 +257,8 @@ export function ComparisonChart({ comparison }: ComparisonChartProps) {
           Cost comparison
         </CardTitle>
         <CardDescription>
-          Vault totals render as single bars while DIY options reveal their full
-          cost stack.
+          Foundation splits into base cost and restore overage when applicable;
+          DIY options reveal their full cost breakdown.
         </CardDescription>
       </CardHeader>
       <CardContent className="pt-6">
@@ -362,7 +366,7 @@ export function ComparisonChart({ comparison }: ComparisonChartProps) {
             </BarChart>
           </ResponsiveContainer>
         </div>
-        <ChartLegend data={data} />
+        <ChartLegend data={data} hasFoundationOverage={hasFoundationOverage} />
       </CardContent>
     </Card>
   );

--- a/src/components/results/comparison-chart.tsx
+++ b/src/components/results/comparison-chart.tsx
@@ -244,6 +244,7 @@ function WrappedXAxisTick({
 
 export function ComparisonChart({ comparison }: ComparisonChartProps) {
   const data = buildChartData(comparison);
+  const hasFoundationOverage = data.some((d) => d.vaultFoundationOverage > 0);
 
   return (
     <Card className="border-border/50 bg-background/90 overflow-hidden rounded-[1.75rem] pt-0">
@@ -304,7 +305,7 @@ export function ComparisonChart({ comparison }: ComparisonChartProps) {
                 stackId="cost"
                 fill="var(--success)"
                 legendType="none"
-                radius={[6, 6, 0, 0]}
+                radius={hasFoundationOverage ? [0, 0, 0, 0] : [6, 6, 0, 0]}
               />
               <Bar
                 dataKey="vaultFoundationOverage"


### PR DESCRIPTION
## Summary

Closes #62

- Splits the VDC Vault Foundation bar into two stacked segments: **Base cost** (green, `var(--success)`) and **Restore Overage** (amber, `var(--warning)`)
- Overage segment is derived from the existing `VaultCostResult.overage` field already computed by the comparison engine — no engine or type changes needed
- When overage is zero (restore ≤ 20%) the bar is visually unchanged; the zero-height segment is silently filtered by the existing `entries.filter(value > 0)` guard in `ChartTooltip`
- Foundation tooltip now shows both lines with `%` share when overage is present, matching the DIY multi-segment experience
- Legend gains a **Restore Overage** swatch only when `vaultFoundationOverage > 0`

## Test plan

- [x] `npm run test:run` — 336 tests pass (3 new: legend conditional, bar rect count 13 with overage, tooltip pct with two Foundation segments)
- [x] `npm run lint` — clean
- [x] `npm run build` — production build succeeds
- [x] Existing bar-count test (12 rects, no overage fixture) still passes
- [x] Existing single-segment Foundation tooltip test (no `%`) still passes
- [x] No new animation classes — reduced-motion coverage unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)