### PR TITLE
fix: address code review corrections (timeout cleanup, capacity bound, tie badge test)

### DIFF
--- a/src/__tests__/summary-cards.test.tsx
+++ b/src/__tests__/summary-cards.test.tsx
@@ -194,6 +194,37 @@ describe("SummaryCards", () => {
     expect(screen.getByText("$14/TB/mo")).toHaveClass("font-mono");
   });
 
+  it("shows Lowest total badge on both cards when they share the minimum cost", () => {
+    // Set Foundation total equal to diyOption2 total so they tie at $4,500
+    render(
+      <SummaryCards
+        comparison={{
+          ...fixtureComparison,
+          vaultFoundation: {
+            total: 4500,
+            perTbMonth: 12.5,
+            pricingTbd: false,
+          },
+        }}
+        capacityTiB={FIXTURE_CAPACITY_TIB}
+        termYears={FIXTURE_TERM_YEARS}
+      />,
+    );
+
+    const badges = screen.getAllByText("Lowest total");
+    expect(badges).toHaveLength(2);
+
+    const foundationCard = screen
+      .getByText("VDC Vault Foundation")
+      .closest('[data-slot="card"]');
+    const diyOption2Card = screen
+      .getByText("S3 Infrequent Access")
+      .closest('[data-slot="card"]');
+
+    expect(foundationCard).toHaveClass("bg-card-tint-success");
+    expect(diyOption2Card).toHaveClass("bg-card-tint-success");
+  });
+
   it("shows ZRS not available text and excludes it from cheapest when option1 unavailable", () => {
     render(
       <SummaryCards

--- a/src/__tests__/url-params.test.ts
+++ b/src/__tests__/url-params.test.ts
@@ -77,8 +77,26 @@ describe("parseUrlParams", () => {
     expect(parseUrlParams("?capacity=1")).toEqual({ capacityTiB: 1 });
   });
 
-  it("accepts large capacity values", () => {
-    expect(parseUrlParams("?capacity=10000")).toEqual({ capacityTiB: 10000 });
+  it("accepts capacity=100000 (maximum)", () => {
+    expect(parseUrlParams("?capacity=100000")).toEqual({
+      capacityTiB: 100_000,
+    });
+  });
+
+  it("omits capacity=100001 (above maximum)", () => {
+    const result = parseUrlParams("?capacity=100001");
+    expect(result).not.toHaveProperty("capacityTiB");
+  });
+
+  it("round-trips capacity=100000 through serialiseUrlParams", () => {
+    const inputs: CalculatorInputs = {
+      regionId: "aws-us-east-1",
+      termYears: 1,
+      capacityTiB: 100_000,
+      restorePercentage: 20,
+    };
+    const result = parseUrlParams("?" + serialiseUrlParams(inputs));
+    expect(result.capacityTiB).toBe(100_000);
   });
 
   it("ignores unknown params", () => {

--- a/src/hooks/use-url-state.ts
+++ b/src/hooks/use-url-state.ts
@@ -33,6 +33,14 @@ export function useUrlState(): UseUrlStateResult {
 
   const pushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  useEffect(() => {
+    return () => {
+      if (pushTimeoutRef.current !== null) {
+        clearTimeout(pushTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const syncToUrl = useCallback((inputs: CalculatorInputs | null) => {
     if (pushTimeoutRef.current !== null) {
       clearTimeout(pushTimeoutRef.current);

--- a/src/lib/url-params.ts
+++ b/src/lib/url-params.ts
@@ -3,6 +3,7 @@ import type { CalculatorInputs } from "@/types/calculator";
 const TERM_MIN = 1;
 const TERM_MAX = 5;
 const CAPACITY_MIN = 1;
+const CAPACITY_MAX = 100_000;
 const RESTORE_MIN = 0;
 const RESTORE_MAX = 100;
 const DEFAULT_RESTORE_PERCENTAGE = 20;
@@ -27,7 +28,11 @@ export function parseUrlParams(search: string): Partial<CalculatorInputs> {
   const capacityRaw = params.get("capacity");
   if (capacityRaw !== null) {
     const capacity = parseInt(capacityRaw, 10);
-    if (!isNaN(capacity) && capacity >= CAPACITY_MIN) {
+    if (
+      !isNaN(capacity) &&
+      capacity >= CAPACITY_MIN &&
+      capacity <= CAPACITY_MAX
+    ) {
       result.capacityTiB = capacity;
     }
   }


### PR DESCRIPTION
Closes #70

## Summary

Three correctness fixes surfaced during a full codebase review.

- **`use-url-state`**: Clear the debounced `pushState` timeout on unmount so it doesn't fire into a dead component
- **`url-params`**: Add `CAPACITY_MAX = 100_000` guard — crafted share links with absurdly large capacity values (e.g. `?capacity=999999999`) are now rejected rather than propagating into the calculator
- **`summary-cards`**: Add test that locks in the existing tie-badge behaviour (both cards show "Lowest total" when they share the minimum cost)

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npm run test:run` — 339 tests pass (3 new: 2 for capacity bound, 1 for tie badge)
- [ ] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)