### PR TITLE
refactor: code cleanup from review (import order, dead export, splice, chart constant, comments)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,12 @@ import { CalculatorForm } from "@/components/calculator/calculator-form";
 import { SiteFooter } from "@/components/layout/site-footer";
 import { SiteHeader } from "@/components/layout/site-header";
 import { MissingCloudPricingAlert } from "@/components/results/missing-cloud-pricing-alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 const ResultsPanel = lazy(async () => {
   const m = await import("@/components/results/results-panel");
   return { default: m.ResultsPanel };
 });
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { CLOUD_PRICING } from "@/data/cloud-pricing";
 import { useRegions } from "@/hooks/use-regions";
 import { useUrlState } from "@/hooks/use-url-state";

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -31,7 +31,6 @@ const regions: Region[] = [
 ];
 
 const defaultUrlState = {
-  initialValues: {},
   urlDerivedInputs: {},
   urlKey: "",
   syncToUrl: vi.fn(),
@@ -136,11 +135,6 @@ describe("App", () => {
 
   it("pre-populates the form and auto-shows results when URL has all three params", async () => {
     vi.mocked(useUrlState).mockReturnValue({
-      initialValues: {
-        regionId: "aws-us-east-1",
-        termYears: 3,
-        capacityTiB: 8,
-      },
       urlDerivedInputs: {
         regionId: "aws-us-east-1",
         termYears: 3,

--- a/src/__tests__/use-url-state.test.tsx
+++ b/src/__tests__/use-url-state.test.tsx
@@ -31,15 +31,15 @@ describe("useUrlState", () => {
     vi.useRealTimers();
   });
 
-  it("returns empty initialValues when no URL params present", () => {
+  it("returns empty urlDerivedInputs when no URL params present", () => {
     const { result } = renderHook(() => useUrlState());
-    expect(result.current.initialValues).toEqual({});
+    expect(result.current.urlDerivedInputs).toEqual({});
   });
 
   it("parses all three fields from URL on mount", () => {
     setLocationSearch("?region=aws-us-east-1&term=3&capacity=50");
     const { result } = renderHook(() => useUrlState());
-    expect(result.current.initialValues).toEqual({
+    expect(result.current.urlDerivedInputs).toEqual({
       regionId: "aws-us-east-1",
       termYears: 3,
       capacityTiB: 50,

--- a/src/components/results/comparison-chart.tsx
+++ b/src/components/results/comparison-chart.tsx
@@ -204,6 +204,10 @@ export function ChartTooltip({
   );
 }
 
+// Max characters per tick line — tuned so labels fit within a single bar column
+// at the chart's default rendered width (~960 px / 4–5 bars).
+const TICK_WRAP_AT_CHARS = 14;
+
 function WrappedXAxisTick({
   x = 0,
   y = 0,
@@ -218,7 +222,7 @@ function WrappedXAxisTick({
   let current = "";
   for (const word of words) {
     const candidate = current ? `${current} ${word}` : word;
-    if (candidate.length > 14 && current) {
+    if (candidate.length > TICK_WRAP_AT_CHARS && current) {
       lines.push(current);
       current = word;
     } else {

--- a/src/components/results/cost-breakdown-table.tsx
+++ b/src/components/results/cost-breakdown-table.tsx
@@ -56,7 +56,19 @@ export function CostBreakdownTable({
     const fmt1 = (val: number) =>
       comparison.diyOption1Unavailable ? "N/A" : formatUSD(val);
 
-    const rows: BreakdownRow[] = [
+    const overage = comparison.vaultFoundation.overage;
+    const overageRow: BreakdownRow | undefined =
+      overage !== undefined && overage > 0
+        ? {
+            category: "Restore Overage (> 20%)",
+            foundation: formatUSD(overage),
+            advanced: "--",
+            diyOption1: "--",
+            diyOption2: "--",
+          }
+        : undefined;
+
+    return [
       {
         category: "Storage",
         foundation: formatVaultStorageCost(comparison.vaultFoundation),
@@ -85,6 +97,7 @@ export function CostBreakdownTable({
         diyOption1: fmt1(comparison.diyOption1.dataRetrieval),
         diyOption2: formatUSD(comparison.diyOption2.dataRetrieval),
       },
+      ...(overageRow ? [overageRow] : []),
       {
         category: excludeEgress
           ? "Internet Egress (excluded)"
@@ -95,19 +108,6 @@ export function CostBreakdownTable({
         diyOption2: formatUSD(comparison.diyOption2.internetEgress),
       },
     ];
-
-    const overage = comparison.vaultFoundation.overage;
-    if (overage !== undefined && overage > 0) {
-      rows.splice(4, 0, {
-        category: "Restore Overage (> 20%)",
-        foundation: formatUSD(overage),
-        advanced: "--",
-        diyOption1: "--",
-        diyOption2: "--",
-      });
-    }
-
-    return rows;
   }, [comparison, excludeEgress]);
 
   return (

--- a/src/hooks/use-url-state.ts
+++ b/src/hooks/use-url-state.ts
@@ -4,18 +4,12 @@ import { parseUrlParams, serialiseUrlParams } from "@/lib/url-params";
 import type { CalculatorInputs } from "@/types/calculator";
 
 interface UseUrlStateResult {
-  initialValues: Partial<CalculatorInputs>;
   urlDerivedInputs: Partial<CalculatorInputs>;
   urlKey: string;
   syncToUrl: (inputs: CalculatorInputs | null) => void;
 }
 
 export function useUrlState(): UseUrlStateResult {
-  const initialValues = useMemo(
-    () => parseUrlParams(window.location.search),
-    [],
-  );
-
   const [currentSearch, setCurrentSearch] = useState(window.location.search);
 
   const urlDerivedInputs = useMemo(
@@ -53,5 +47,5 @@ export function useUrlState(): UseUrlStateResult {
     }, 300);
   }, []);
 
-  return { initialValues, urlDerivedInputs, urlKey: currentSearch, syncToUrl };
+  return { urlDerivedInputs, urlKey: currentSearch, syncToUrl };
 }

--- a/src/lib/diy-calculator.ts
+++ b/src/lib/diy-calculator.ts
@@ -22,6 +22,8 @@ export function calculateStorageCost(
  * Write ops cost.
  * Number of ops = capacityTiB × TIB_TO_MB / OPERATION_SIZE_MB
  * Each batch of opsBatchSize ops costs opsCost dollars.
+ *
+ * @param termMonths - Uses months (not years) to match the monthly storage billing cycle.
  */
 export function calculateWriteOpsCost(
   capacityTiB: number,
@@ -36,6 +38,9 @@ export function calculateWriteOpsCost(
 /**
  * Read ops cost.
  * Assumes readFactor of stored data is read back per year (defaults to ANNUAL_READ_FACTOR).
+ *
+ * @param termYears - Uses years (not months) because the restore factor is an annual rate.
+ *   This is intentionally different from calculateWriteOpsCost which uses termMonths.
  */
 export function calculateReadOpsCost(
   capacityTiB: number,


### PR DESCRIPTION
Closes #71

## Summary

Pure cleanup pass — zero behavioral changes, no new tests required.

- **`App.tsx`**: Move `Alert` import above the `lazy` const declaration so all static imports are grouped together
- **`use-url-state`**: Remove unused `initialValues` from hook return; `urlDerivedInputs` already serves the same purpose and responds to navigation
- **`cost-breakdown-table`**: Replace `rows.splice(4, 0, ...)` with a conditional spread so the overage row position is structurally expressed, not a magic index
- **`comparison-chart`**: Extract the hardcoded `14`-char wrap threshold into `TICK_WRAP_AT_CHARS` with an explanatory comment
- **`diy-calculator`**: Add `@param` notes clarifying the intentional unit asymmetry between `calculateWriteOpsCost` (months) and `calculateReadOpsCost` (years)

> Note: `ChartTooltip` was reviewed as a candidate for un-exporting, but the test suite imports it directly to cover percentage calculation logic — the export is intentional.

## Test plan

- [ ] `npm run lint` — clean
- [ ] `npm run test:run` — 336 tests pass (same count, no additions or removals)
- [ ] `npm run build` — succeeds
- [ ] Manual: load app with restore % > 20%, confirm "Restore Overage" row appears correctly in breakdown table

🤖 Generated with [Claude Code](https://claude.com/claude-code)