### PR TITLE
docs(assumptions): clarify monthly full-backup write cadence assumption

### DIFF
--- a/src/components/results/assumptions.tsx
+++ b/src/components/results/assumptions.tsx
@@ -29,6 +29,9 @@ export function Assumptions({ restorePercentage }: AssumptionsProps) {
         <ul className="text-muted-foreground grid gap-3 pt-5 text-sm leading-6">
           <li>
             1 MB operation size is applied to every write and read transaction.
+            Write operations assume the full dataset is re-written once per
+            month (equivalent to a monthly full backup); actual costs will be
+            lower for incremental-only workloads.
           </li>
           <li>
             {restorePercentage}% annual restore is assumed for data read back


### PR DESCRIPTION
## Summary

Closes #79

The **Calculation Assumptions** panel mentioned the 1 MB operation size but didn't explain the write cadence model: the calculator assumes the full dataset is re-written once per month. This is the primary driver of DIY write ops costs and is important context for users with incremental-only backup workloads.

## Change

Expanded the write ops bullet in `src/components/results/assumptions.tsx`:

**Before:**
> 1 MB operation size is applied to every write and read transaction.

**After:**
> 1 MB operation size is applied to every write and read transaction. Write operations assume the full dataset is re-written once per month (equivalent to a monthly full backup); actual costs will be lower for incremental-only workloads.

## Testing

- UI copy only — no logic changes
- `npm run lint` ✅
- `npm run test:run` — all 339 tests pass ✅